### PR TITLE
Add Frontend Unit Testing Support with Jasmine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml>
+    <jasmine.serverPort>8000</jasmine.serverPort>
   </properties>
 
   <dependencies>
@@ -39,7 +40,7 @@
       <plugin>
         <groupId>com.github.searls</groupId>
         <artifactId>jasmine-maven-plugin</artifactId>
-        <version>1.3.1.3</version>
+        <version>2.2</version>
         <executions>
           <execution>
             <id>jasmine-bdd</id>
@@ -56,7 +57,7 @@
         </executions>
         <configuration>
           <jsSrcDir>${project.basedir}/src/main/webapp/scripts</jsSrcDir>
-          <jsTestSrcDir>${project.basedir}/src/test/jasmine/tests</jsTestSrcDir>
+          <jsTestSrcDir>${project.basedir}/src/main/webapp/tests</jsTestSrcDir>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,6 @@
                 <goal>bdd</goal>
               </goals>
           </execution>
-          <execution>
-           <id>jasmine-test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-          </execution>
         </executions>
         <configuration>
           <jsSrcDir>${project.basedir}/src/main/webapp/scripts</jsSrcDir>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,29 @@
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.github.searls</groupId>
+        <artifactId>jasmine-maven-plugin</artifactId>
+        <version>1.3.1.3</version>
+        <executions>
+          <execution>
+            <id>jasmine-bdd</id>
+              <goals>
+                <goal>bdd</goal>
+              </goals>
+          </execution>
+          <execution>
+           <id>jasmine-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <jsSrcDir>${project.basedir}/src/main/webapp/scripts</jsSrcDir>
+          <jsTestSrcDir>${project.basedir}/src/test/jasmine/tests</jsTestSrcDir>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/webapp/scripts/place-suggestions.js
+++ b/src/main/webapp/scripts/place-suggestions.js
@@ -31,7 +31,7 @@ function findNearbyPlaces() {
  */
 function callback(results, status) {
   if (status === google.maps.places.PlacesServiceStatus.OK) {
-    for (var i = 0; i < results.length; i++) {
+    for (let i = 0; i < results.length; i++) {
       console.log(results[i].name);
     }
   }

--- a/src/main/webapp/scripts/trips-network.js
+++ b/src/main/webapp/scripts/trips-network.js
@@ -95,7 +95,7 @@ function loadSharedTripsData() {
                 <h6>Rating: ${rating}</h6>
               </div>
               <div class="right-align">
-                <h6>${new Date(timestamp).toLocaleDateString()}</h6>
+                <h6>${unixTimestampToString(timestamp)}</h6>
               </div>
               <p>${description}</p>
               <ul class="collection with-header">
@@ -120,4 +120,12 @@ function loadSharedTripsData() {
         </div>
       `
   ).join(" ");
+}
+
+/**
+ * Converts Unix epoch time number to a string of the form MM/DD/YYYY.
+ * @param {number} timestamp
+ */
+function unixTimestampToString(timestamp) {
+  return new Date(timestamp).toLocaleDateString();
 }

--- a/src/main/webapp/scripts/trips-network.js
+++ b/src/main/webapp/scripts/trips-network.js
@@ -124,6 +124,8 @@ function loadSharedTripsData() {
 
 /**
  * Converts Unix epoch time number to a string of the form MM/DD/YYYY.
+ * Uses the client timezone to calculate the string; behavior can differ
+ * on different devices.
  * @param {number} timestamp
  */
 function unixTimestampToString(timestamp) {

--- a/src/main/webapp/tests/trips-network.test.js
+++ b/src/main/webapp/tests/trips-network.test.js
@@ -1,0 +1,5 @@
+describe("Test unix timestamp toString converter", () => {
+  it("converts timestamps correctly", () => {
+    expect(add(0, 0)).toBe("6/29/2020");
+  });
+});

--- a/src/main/webapp/tests/trips-network.test.js
+++ b/src/main/webapp/tests/trips-network.test.js
@@ -1,5 +1,7 @@
 describe("Test unix timestamp toString converter", () => {
   it("converts timestamps correctly", () => {
     expect(unixTimestampToString(1593466864528)).toBe("6/29/2020");
+    expect(unixTimestampToString(1593620880101)).toBe("7/1/2020");
+    expect(unixTimestampToString(946702800000)).toBe("1/1/2000");
   });
 });

--- a/src/main/webapp/tests/trips-network.test.js
+++ b/src/main/webapp/tests/trips-network.test.js
@@ -2,6 +2,6 @@ describe("Test unix timestamp toString converter", () => {
   it("converts timestamps correctly", () => {
     expect(unixTimestampToString(1593466864528)).toBe("6/29/2020");
     expect(unixTimestampToString(1593620880101)).toBe("7/1/2020");
-    expect(unixTimestampToString(946702800000)).toBe("1/1/2000");
+    expect(unixTimestampToString(946752900000)).toBe("1/1/2000");
   });
 });

--- a/src/main/webapp/tests/trips-network.test.js
+++ b/src/main/webapp/tests/trips-network.test.js
@@ -1,5 +1,5 @@
 describe("Test unix timestamp toString converter", () => {
   it("converts timestamps correctly", () => {
-    expect(add(0, 0)).toBe("6/29/2020");
+    expect(unixTimestampToString(1593466864528)).toBe("6/29/2020");
   });
 });


### PR DESCRIPTION
### Motivation
We want to follow test-driven development even when developing our frontend functions, and since our project uses Maven for build, we can't use Jest. I looked more into it, and it seems Jasmine is used internally, so we can adopt the `jasmine-maven-plugin` which is open-sourced and allows us to use the Jasmine test-driven development framework with Maven. Basically, all you need to do is create a `.js` file with similar format to the existing `trips-network.test.js` file added in this PR, and it will be run by `mvn jasmine:bdd`.

### Screenshot
_@`local server, port 8000`_
![Screenshot 2020-07-01 at 1 11 33 PM](https://user-images.githubusercontent.com/7517829/86272342-690d6800-bb9c-11ea-9a40-3605fb68d6a8.png)

### Test Plan
Run `mvn jasmine:bdd` in the root directory and navigate to `localhost:8000` to view a live-updating server of the tests located in the `src/main/webapp/tests` directory.