### PR TITLE
My Trips Fetching Frontend + Backend Refactor

### DIFF
--- a/src/main/java/com/google/sps/data/Trip.java
+++ b/src/main/java/com/google/sps/data/Trip.java
@@ -10,7 +10,9 @@ import com.google.auto.value.AutoValue;
 public abstract class Trip {
 
   public static final String ENTITY_PROPERTY_TITLE = "title";
-  public static final String ENTITY_PROPERTY_HOTEL = "hotel";
+  public static final String ENTITY_PROPERTY_HOTEL_ID = "hotel_id";
+  public static final String ENTITY_PROPERTY_HOTEL_NAME = "hotel_name";
+  public static final String ENTITY_PROPERTY_HOTEL_IMAGE = "hotel_img";
   public static final String ENTITY_PROPERTY_RATING = "rating";
   public static final String ENTITY_PROPERTY_DESCRIPTION = "description";
   public static final String ENTITY_PROPERTY_OWNER = "owner";
@@ -20,7 +22,11 @@ public abstract class Trip {
   public abstract String title();
 
   // represented by a Place ID string
-  public abstract String hotel();
+  public abstract String hotelID();
+
+  public abstract String hotelName();
+
+  public abstract String hotelImage();
 
   // [1, 5], scale=0.5
   public abstract double rating();
@@ -35,18 +41,18 @@ public abstract class Trip {
 
   public static Builder builder() {
     // initialize fields not required at first creation
-    return new AutoValue_Trip.Builder()
-                .setHotel("")
-                .setRating(-1)
-                .setDescription("")
-                .setIsPublic(false);
+    return new AutoValue_Trip.Builder().setRating(-1).setDescription("").setIsPublic(false);
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setTitle(String value);
 
-    public abstract Builder setHotel(String value);
+    public abstract Builder setHotelID(String value);
+
+    public abstract Builder setHotelName(String value);
+
+    public abstract Builder setHotelImage(String value);
 
     public abstract Builder setRating(double value);
 

--- a/src/main/java/com/google/sps/data/Trip.java
+++ b/src/main/java/com/google/sps/data/Trip.java
@@ -17,6 +17,7 @@ public abstract class Trip {
   public static final String ENTITY_PROPERTY_DESCRIPTION = "description";
   public static final String ENTITY_PROPERTY_OWNER = "owner";
   public static final String ENTITY_PROPERTY_PUBLIC = "is_public";
+  public static final String ENTITY_PROPERTY_PAST_TRIP = "is_past_trip";
   public static final String ENTITY_PROPERTY_TIMESTAMP = "timestamp";
 
   public abstract String title();
@@ -35,13 +36,19 @@ public abstract class Trip {
 
   public abstract String owner();
 
+  public abstract boolean isPastTrip();
+
   public abstract boolean isPublic();
 
   public abstract long timestamp();
 
   public static Builder builder() {
     // initialize fields not required at first creation
-    return new AutoValue_Trip.Builder().setRating(-1).setDescription("").setIsPublic(false);
+    return new AutoValue_Trip.Builder()
+                .setRating(-1)
+                .setDescription("")
+                .setIsPublic(false)
+                .setIsPastTrip(false);
   }
 
   @AutoValue.Builder
@@ -59,6 +66,8 @@ public abstract class Trip {
     public abstract Builder setDescription(String value);
 
     public abstract Builder setOwner(String value);
+
+    public abstract Builder setIsPastTrip(boolean value);
 
     public abstract Builder setIsPublic(boolean value);
 

--- a/src/main/java/com/google/sps/data/TripLocation.java
+++ b/src/main/java/com/google/sps/data/TripLocation.java
@@ -11,15 +11,18 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 public abstract class TripLocation {
-  public static final String ENTITY_PROPERTY_PLACE = "place_id";
+  public static final String ENTITY_PROPERTY_PLACE_ID = "place_id";
+  public static final String ENTITY_PROPERTY_PLACE_NAME = "place_name";
   public static final String ENTITY_PROPERTY_WEIGHT = "weight";
   public static final String ENTITY_PROPERTY_OWNER = "owner";
 
-  public static TripLocation create(String placeID, int weight, String owner) {
-    return new AutoValue_TripLocation(placeID, weight, owner);
+  public static TripLocation create(String placeID, String placeName, int weight, String owner) {
+    return new AutoValue_TripLocation(placeID, placeName, weight, owner);
   }
 
   public abstract String placeID();
+
+  public abstract String placeName();
 
   public abstract int weight();
 

--- a/src/main/java/com/google/sps/servlets/TripsServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripsServlet.java
@@ -144,6 +144,7 @@ public class TripsServlet extends HttpServlet {
     double rating = (double) entity.getProperty(Trip.ENTITY_PROPERTY_RATING);
     String description = (String) entity.getProperty(Trip.ENTITY_PROPERTY_DESCRIPTION);
     String owner = (String) entity.getProperty(Trip.ENTITY_PROPERTY_OWNER);
+    boolean isPastTrip = (boolean) entity.getProperty(Trip.ENTITY_PROPERTY_PAST_TRIP);
     boolean isPublic = (boolean) entity.getProperty(Trip.ENTITY_PROPERTY_PUBLIC);
     long timestamp = (long) entity.getProperty(Trip.ENTITY_PROPERTY_TIMESTAMP);
 
@@ -155,6 +156,7 @@ public class TripsServlet extends HttpServlet {
             .setRating(rating)
             .setDescription(description)
             .setOwner(owner)
+            .setIsPastTrip(isPastTrip)
             .setIsPublic(isPublic)
             .setTimestamp(timestamp)
             .build();
@@ -205,6 +207,7 @@ public class TripsServlet extends HttpServlet {
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_RATING, trip.rating());
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_DESCRIPTION, trip.description());
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_OWNER, trip.owner());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_PAST_TRIP, trip.isPastTrip());
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_PUBLIC, trip.isPublic());
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_TIMESTAMP, trip.timestamp());
     return tripEntity;

--- a/src/main/java/com/google/sps/servlets/TripsServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripsServlet.java
@@ -98,7 +98,9 @@ public class TripsServlet extends HttpServlet {
       
       Trip trip = Trip.builder()
                     .setTitle(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_TITLE).getAsString())
-                    .setHotel(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL).getAsString())
+                    .setHotelID(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL_ID).getAsString())
+                    .setHotelName(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL_NAME).getAsString())
+                    .setHotelImage(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL_IMAGE).getAsString())
                     .setRating(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_RATING).getAsDouble())
                     .setOwner(userEmail)
                     .setTimestamp(timestamp)
@@ -114,9 +116,10 @@ public class TripsServlet extends HttpServlet {
       
       while(locationIterator.hasNext()) {
         JsonObject curr = locationIterator.next().getAsJsonObject();
-        String place = curr.getAsJsonPrimitive("id").getAsString();
+        String placeID = curr.getAsJsonPrimitive("id").getAsString();
+        String placeName = curr.getAsJsonPrimitive("name").getAsString();
         int weight = curr.getAsJsonPrimitive("weight").getAsInt();
-        TripLocation location = TripLocation.create(place, weight, userEmail);
+        TripLocation location = TripLocation.create(placeID, placeName, weight, userEmail);
         datastore.put(convertTripLocationToEntity(location, tripEntity));
       }
 
@@ -135,7 +138,9 @@ public class TripsServlet extends HttpServlet {
    */
   public static Trip convertEntityToTrip(Entity entity) {
     String title = (String) entity.getProperty(Trip.ENTITY_PROPERTY_TITLE);
-    String hotel = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL);
+    String hotelID = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL_ID);
+    String hotelName = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL_NAME);
+    String hotelImage = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL_IMAGE);
     double rating = (double) entity.getProperty(Trip.ENTITY_PROPERTY_RATING);
     String description = (String) entity.getProperty(Trip.ENTITY_PROPERTY_DESCRIPTION);
     String owner = (String) entity.getProperty(Trip.ENTITY_PROPERTY_OWNER);
@@ -144,7 +149,9 @@ public class TripsServlet extends HttpServlet {
 
     return Trip.builder()
             .setTitle(title)
-            .setHotel(hotel)
+            .setHotelID(hotelID)
+            .setHotelName(hotelName)
+            .setHotelImage(hotelImage)
             .setRating(rating)
             .setDescription(description)
             .setOwner(owner)
@@ -160,10 +167,11 @@ public class TripsServlet extends HttpServlet {
    * @return TripLocation object with corresponding fields to the entity
    */
   public static TripLocation convertEntityToTripLocation(Entity entity) {
-    String placeID = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_PLACE);
+    String placeID = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_PLACE_ID);
+    String placeName = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_PLACE_NAME);
     int weight = Math.toIntExact((long) entity.getProperty(TripLocation.ENTITY_PROPERTY_WEIGHT));
     String owner = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_OWNER);
-    return TripLocation.create(placeID, weight, owner);
+    return TripLocation.create(placeID, placeName, weight, owner);
   }
 
   /**
@@ -175,7 +183,8 @@ public class TripsServlet extends HttpServlet {
    */
   public static Entity convertTripLocationToEntity(TripLocation location, Entity parent) {
     Entity tripLocationEntity = new Entity("trip-location", parent.getKey());
-    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_PLACE, location.placeID());
+    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_PLACE_ID, location.placeID());
+    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_PLACE_NAME, location.placeName());
     tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_WEIGHT, location.weight());
     tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_OWNER, location.owner());
     return tripLocationEntity;
@@ -190,7 +199,9 @@ public class TripsServlet extends HttpServlet {
   public static Entity convertTripToEntity(Trip trip) {
     Entity tripEntity = new Entity("trip");
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_TITLE, trip.title());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL, trip.hotel());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_ID, trip.hotelID());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_NAME, trip.hotelName());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_IMAGE, trip.hotelImage());
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_RATING, trip.rating());
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_DESCRIPTION, trip.description());
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_OWNER, trip.owner());

--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -96,11 +96,7 @@
           <h3>Past Trips</h3>
         </div>
       </div>
-      <div class="row">
-        <div class="col s12">
-          <p class="placeholder-text">No past trips to show.</p>
-        </div>
-      </div>
+      <div id="past-trips-container"></div>
     </div>
     <footer class="page-footer blue lighten-1">
       <div class="footer-copyright">

--- a/src/main/webapp/scripts/constant-script.js
+++ b/src/main/webapp/scripts/constant-script.js
@@ -20,7 +20,7 @@ const GOOGLE_API_KEY = "AIzaSyDlLtx69Y4-65_dCK67ZX3lzKTYpyc5CWI";
 document.addEventListener("DOMContentLoaded", () => {
   const sidenavElems = document.querySelectorAll(".sidenav");
   const sideNavInstances = M.Sidenav.init(sidenavElems, undefined);
-  const modalElems = document.querySelectorAll('.modal');
+  const modalElems = document.querySelectorAll(".modal");
   const modalInstances = M.Modal.init(modalElems, undefined);
 });
 
@@ -115,4 +115,14 @@ function parseSerializedJson(json) {
   }
 
   return obj;
+}
+
+/**
+ * Converts Unix epoch time number to a string of the form MM/DD/YYYY.
+ * Uses the client timezone to calculate the string; behavior can differ
+ * on different devices.
+ * @param {number} timestamp
+ */
+function unixTimestampToString(timestamp) {
+  return new Date(timestamp).toLocaleDateString();
 }

--- a/src/main/webapp/scripts/constant-script.js
+++ b/src/main/webapp/scripts/constant-script.js
@@ -122,6 +122,7 @@ function parseSerializedJson(json) {
  * Uses the client timezone to calculate the string; behavior can differ
  * on different devices.
  * @param {number} timestamp
+ * @returns {string} date corresponding to timestamp in MM/DD/YYYY form.
  */
 function unixTimestampToString(timestamp) {
   return new Date(timestamp).toLocaleDateString();

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -284,7 +284,7 @@ async function parseAndRenderHotelResults(json, centerPoint) {
                 <div class="card-action center">
                   <button 
                     class="btn indigo" 
-                    onClick="saveTrip("${place_id}", "${photo_url}", "${name})"
+                    onClick="saveTrip('${place_id}', '${photo_url}', '${name}')"
                   >
                     CHOOSE
                   </button>
@@ -414,7 +414,7 @@ async function fetchAndRenderTripsFromDB() {
   );
   plannedTripsHTMLElement.innerHTML = "";
   pastTripsHTMLElement.innerHTML = "";
-
+  console.log(tripsData);
   let isPlannedTripsEmpty = true;
   let isPastTripsEmpty = true;
   for (key of keys) {
@@ -422,14 +422,16 @@ async function fetchAndRenderTripsFromDB() {
     // Deserialize using parseSerializedJson.
     const {
       title,
-      hotel_name,
-      hotel_img,
-      is_past_trip,
+      hotelName,
+      hotelImage,
+      isPastTrip,
       timestamp,
+      hotelID,
+      isPublic
     } = parseSerializedJson(key);
     const locations = tripsData[key];
     let HTMLElementToUpdate;
-    if (is_past_trip) {
+    if (isPastTrip === "true") {
       isPastTripsEmpty = false;
       HTMLElementToUpdate = pastTripsHTMLElement;
     } else {
@@ -442,32 +444,37 @@ async function fetchAndRenderTripsFromDB() {
           <div class="card">
             <div class="card-content">
               <span class="card-title">${title}</span>
-              <p>Created on ${unixTimestampToString(timestamp)}</p>
-              <form>
-                <div id="trip-${timestamp}-locations"></div>
-              </form>
+              <div id="trip-${timestamp}-locations"></div>
+              <div id="trip-${timestamp}-map" class="trip-map"></div>
             </div>
           </div>
         </div>
         <div class="col m4">
-          <div class="card">
+          <div class="card medium">
             <div class="card-image">
-              <img src="${hotel_img}">
+              <img src="${hotelImage}">
             </div>
             <div class="card-content">
-              <span class="card-title">${hotel_name}</span>
+              <span class="card-title">${hotelName}</span>
               <div id="trip-${timestamp}-locations"></div>
             </div>
           </div>
         </div>
       </div>
     `;
+    // Get coords of all locations in this trip and the hotel to add to the Google map
+    const tripMap = new google.maps.Map(document.getElementById(`trip-${timestamp}-map`), undefined);
+    const service = new google.maps.places.PlacesService(tripMap);
+
+    const coords = [];
+    coords.
+    
     document.getElementById(`trip-${timestamp}-locations`).innerHTML = locations
-      .map(({ weight, place_name }) => {
+      .map(({ weight, placeName }) => {
         return `
           <div class="row">
             <div class="col s6">
-              <span><strong>${place_name}</strong></span>
+              <span><strong>${placeName}</strong></span>
             </div>
             <div class="col s6">
               <span>Weight: ${weight}</span>

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -198,10 +198,11 @@ async function findHotel() {
  */
 async function parseAndRenderHotelResults(json, centerPoint) {
   const modalContent = document.getElementById("hotel-results");
-  if (!json) {
-    modalContent.innerText = "No hotels nearby. Sorry.";
+  const hotelsMapElem = document.getElementById("hotels-map");
+  if (!json || json.length === 0) {
+    modalContent.innerText = "We couldn't find any hotels nearby. Sorry about that.";
+    hotelsMapElem.innerHTML = "";
   } else {
-    const hotelsMapElem = document.getElementById("hotels-map");
     json = json.slice(0, 10);
     const hotelMap = new google.maps.Map(
       document.getElementById("hotels-map"),
@@ -239,7 +240,7 @@ async function parseAndRenderHotelResults(json, centerPoint) {
       });
       marker.addListener("click", () => infoWindow.open(hotelMap, marker));
       obj.distance_center = distanceBetween(location, centerPoint);
-      const photoRef = obj.photos[0]
+      const photoRef = (obj.photos && Array.isArray(obj.photos))
         ? obj.photos[0].photo_reference
         : undefined;
       if (photoRef) {
@@ -256,6 +257,7 @@ async function parseAndRenderHotelResults(json, centerPoint) {
     });
     json = await Promise.all(json);
     json.sort((a, b) => a.distance_center - b.distance_center);
+    
     hotelsMapElem.style.width = "100%";
     hotelsMapElem.style.height = "400px";
     hotelsMapElem.style.marginBottom = "2em";

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -282,7 +282,12 @@ async function parseAndRenderHotelResults(json, centerPoint) {
                   <p>${formatted_address}</p>
                 </div>
                 <div class="card-action center">
-                  <button id="${place_id}" class="btn indigo" onClick="saveTrip(this.id)">CHOOSE</button>
+                  <button 
+                    class="btn indigo" 
+                    onClick="saveTrip("${place_id}", "${photo_url}", "${name})"
+                  >
+                    CHOOSE
+                  </button>
                 </div>
               </div>
             </div>
@@ -336,7 +341,7 @@ function degToRad(angle) {
  * Saves the current trip the user is editing to My Trips, through a POST request
  * to the backend. Then rerenders the trips based on DB data.
  */
-async function saveTrip(hotelID) {
+async function saveTrip(hotelID, hotelImg, hotelName) {
   const elem = document.getElementById("hotel-modal");
   const instance = M.Modal.getInstance(elem);
   instance.close();
@@ -347,13 +352,16 @@ async function saveTrip(hotelID) {
   for (let i = 1; i <= numLocations; i++) {
     locationData.push({
       id: locationPlaceObjects[i - 1].place_id,
+      name: locationPlaceObjects[i - 1].name,
       weight: document.getElementById(`location-${i}-weight`).value,
     });
   }
 
   const requestBody = {
     title: document.getElementById("trip-title").value,
-    hotel: hotelID,
+    hotel_id: hotelID,
+    hotel_img: hotelImg,
+    hotel_name: hotelName,
     rating: -1,
     locations: locationData,
   };

--- a/src/main/webapp/scripts/trips-network.js
+++ b/src/main/webapp/scripts/trips-network.js
@@ -119,13 +119,3 @@ function loadSharedTripsData() {
       `
   ).join(" ");
 }
-
-/**
- * Converts Unix epoch time number to a string of the form MM/DD/YYYY.
- * Uses the client timezone to calculate the string; behavior can differ
- * on different devices.
- * @param {number} timestamp
- */
-function unixTimestampToString(timestamp) {
-  return new Date(timestamp).toLocaleDateString();
-}

--- a/src/main/webapp/styles/my-trips.css
+++ b/src/main/webapp/styles/my-trips.css
@@ -10,3 +10,8 @@
   color: grey;
   font-size: 18px;
 }
+
+#trip-map {
+  min-height: 300px;
+  width: 100%;
+}

--- a/src/main/webapp/styles/my-trips.css
+++ b/src/main/webapp/styles/my-trips.css
@@ -11,7 +11,7 @@
   font-size: 18px;
 }
 
-#trip-map {
+.trip-map {
   min-height: 300px;
   width: 100%;
 }

--- a/src/test/java/com/google/sps/TripTest.java
+++ b/src/test/java/com/google/sps/TripTest.java
@@ -13,11 +13,16 @@ public class TripTest {
   public void testDefaultBuilderValuesWithRequiredData() {
     Trip defaultTrip = Trip.builder()
                         .setTitle("Trip 1")
+                        .setHotelID("aBcXyZ123")
+                        .setHotelName("Default Hotel")
+                        .setHotelImage("https://google.com/aBcXyZ")
                         .setOwner("test@gmail.com")
                         .setTimestamp(1594160425000L)
                         .build();
     Assert.assertEquals("Trip 1", defaultTrip.title());
-    Assert.assertEquals("", defaultTrip.hotel());
+    Assert.assertEquals("aBcXyZ123", defaultTrip.hotelID());
+    Assert.assertEquals("Default Hotel", defaultTrip.hotelName());
+    Assert.assertEquals("https://google.com/aBcXyZ", defaultTrip.hotelImage());
     Assert.assertEquals(-1, defaultTrip.rating(), 0.01);
     Assert.assertEquals("", defaultTrip.description());
     Assert.assertEquals("test@gmail.com", defaultTrip.owner());

--- a/src/test/java/com/google/sps/TripsServletTest.java
+++ b/src/test/java/com/google/sps/TripsServletTest.java
@@ -31,19 +31,25 @@ public class TripsServletTest {
   public void testValidTripFromEntity() {
     Entity tripEntity = new Entity("trip");
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_TITLE, "foo trip");
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL, "24234235");
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_ID, "24234235");
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_NAME, "SF Hotel");
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_IMAGE, "https://photos.google.com/hotel.png");
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_RATING, 4.5);
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_DESCRIPTION, "lorem ipsummmm");
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_OWNER, "peter@email.com");
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_PAST_TRIP, false);
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_PUBLIC, true);
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_TIMESTAMP, 3942943923949L);
     Trip trip = TripsServlet.convertEntityToTrip(tripEntity);
 
     Assert.assertEquals("foo trip", trip.title());
-    Assert.assertEquals("24234235", trip.hotel());
+    Assert.assertEquals("24234235", trip.hotelID());
+    Assert.assertEquals("SF Hotel", trip.hotelName());
+    Assert.assertEquals("https://photos.google.com/hotel.png", trip.hotelImage());
     Assert.assertEquals(4.5, trip.rating(), 0.001);
     Assert.assertEquals("lorem ipsummmm", trip.description());
     Assert.assertEquals("peter@email.com", trip.owner());
+    Assert.assertEquals(false, trip.isPastTrip());
     Assert.assertEquals(true, trip.isPublic());
     Assert.assertEquals(3942943923949L, trip.timestamp());
   }


### PR DESCRIPTION
### Motivation
Before, the strategy for fetching and rendering trips from the backend that were already created was very clunky: we had to reverse geocode each Place ID for each location and get the name of the location from that. This resulted in a lot of unneeded API calls and was slow on slower internet connections. Also, the data was just directly placed on the page, without any coherent UI. 

### Summary 
This pull request adds prettier display of past/current trips for a user, by fetching an image URL of the hotel for each trip from the backend, as well as names for locations instead of having to figure them out from Place ID strings. The schema for `Trip`s and `TripLocation`s has been updated accordingly, along with the unit tests. 

Now, a user can see the locations on a map for each trip, along with a website for the hotel where they can find more information about booking. There is no "edit trip" feature yet, but this is in the works.

### Screenshot
![Overnightly _ My Trips (6)](https://user-images.githubusercontent.com/7517829/87616344-d237c400-c6e2-11ea-82a4-c1ae109ee9bf.gif)

### Test Plan
Run `mvn package appengine:run` in the root directory on Cloud Shell. Add a trip and see that locations are displayed in a nice way along with the corresponding hotel. Check the admin datastore console using `{long cloudshell.dev address}/_ah/admin` and see that the entity schema is slightly different.

### Breaking Changes
This PR introduces a breaking change to production, requiring us to flush the current deployed DB. This is because of the switch to track not only Place IDs for hotels, but also their name and a corresponding image. As such, the entity property for Hotel IDs are no longer `hotel`, but `hotel_id` for a certain Trip. 

After this PR is merged in and after code review, I will clear the current DB. This is low-risk because we don't have any real users yet (lol)