### PR TITLE
Store photo references instead to fix prod bug and document it

### DIFF
--- a/src/main/java/com/google/sps/data/Trip.java
+++ b/src/main/java/com/google/sps/data/Trip.java
@@ -27,6 +27,7 @@ public abstract class Trip {
 
   public abstract String hotelName();
 
+  // Photo reference String from Places API (not a binary object)
   public abstract String hotelImage();
 
   // [1, 5], scale=0.5


### PR DESCRIPTION
### Summary
After merging in #21, we can now see more information about existing trips, whether past or planned. However, this includes a hotel image, which used to be defined as a URL stored in the backend. This proved to be a bug, since the blob URLs were temporarily created in the frontend with the Places Photo API call, and upon later viewing of the page (refresh), these URLs would be broken.

This PR fixes the issue by storing photo references rather than URLs, and calls the API to get the photo for each photo reference instead of preloading URLs into the backend.

### Screenshots
Should exhibit same behavior as #21. Just fixes it in production.

### Test Plan
Run `mvn package appengine:run` and see that images are displayed for existing trips on page load.