### PR TITLE
formatting: Use singlequote instead of double for JS

### DIFF
--- a/src/main/webapp/scripts/constant-script.js
+++ b/src/main/webapp/scripts/constant-script.js
@@ -14,13 +14,13 @@
 
 // This file contains all the constant scripts to be loaded on each page.
 
-const GOOGLE_API_KEY = "AIzaSyDlLtx69Y4-65_dCK67ZX3lzKTYpyc5CWI";
+const GOOGLE_API_KEY = 'AIzaSyDlLtx69Y4-65_dCK67ZX3lzKTYpyc5CWI';
 
 // Initialize Materialize JS elements when DOM content is fully loaded
-document.addEventListener("DOMContentLoaded", () => {
-  const sidenavElems = document.querySelectorAll(".sidenav");
+document.addEventListener('DOMContentLoaded', () => {
+  const sidenavElems = document.querySelectorAll('.sidenav');
   const sideNavInstances = M.Sidenav.init(sidenavElems, undefined);
-  const modalElems = document.querySelectorAll(".modal");
+  const modalElems = document.querySelectorAll('.modal');
   const modalInstances = M.Modal.init(modalElems, undefined);
 });
 
@@ -29,7 +29,7 @@ document.addEventListener("DOMContentLoaded", () => {
  * they are not logged in. For use on auth-walled pages.
  */
 function authReload() {
-  fetch("/login")
+  fetch('/login')
     .then((response) => response.json())
     .then(({ isLoggedIn, loginUrl, logoutUrl }) => {
       if (isLoggedIn) {
@@ -62,8 +62,8 @@ const LOADING_ANIMATION_HTML = `
  * @param {string} logoutUrl
  */
 function showLogoutButton(logoutUrl) {
-  const mobileSidenav = document.getElementById("mobile-demo");
-  const defaultNav = document.getElementById("menu-links");
+  const mobileSidenav = document.getElementById('mobile-demo');
+  const defaultNav = document.getElementById('menu-links');
   mobileSidenav.innerHTML += `
           <li>
             <a class="waves-effect btn white black-text" href="${logoutUrl}">Logout</a>
@@ -85,31 +85,31 @@ function showLogoutButton(logoutUrl) {
  */
 function parseSerializedJson(json) {
   const charArray = [...json];
-  const startIndex = charArray.indexOf("{");
+  const startIndex = charArray.indexOf('{');
 
   // Build JS object by iterating through
   let obj = {};
   let isField = true;
-  let [currField, currValue] = ["", ""];
+  let [currField, currValue] = ['', ''];
   for (let i = startIndex + 1; i < charArray.length; i++) {
     const currChar = charArray[i];
     if (isField) {
-      if (currChar === " ") {
+      if (currChar === ' ') {
         continue;
       }
-      if (currChar !== "=") {
+      if (currChar !== '=') {
         currField += currChar;
       } else {
         isField = false;
       }
     } else {
-      if (currChar !== "," && currChar !== "}") {
+      if (currChar !== ',' && currChar !== '}') {
         currValue += currChar;
       } else {
         isField = true;
         // add field to obj and reset field and value strings
         obj[currField] = currValue;
-        [currField, currValue] = ["", ""];
+        [currField, currValue] = ['', ''];
       }
     }
   }

--- a/src/main/webapp/scripts/index.js
+++ b/src/main/webapp/scripts/index.js
@@ -4,27 +4,27 @@
  * if user logged out, hide navbar options for auth-walled pages and show sign-in button
  */
 function authUser() {
-  fetch("/login")
+  fetch('/login')
     .then((response) => response.json())
     .then((userAuthInfo) => {
       const { loginUrl, logoutUrl, isLoggedIn } = userAuthInfo;
-      const loginButton = document.getElementById("google-login-button");
+      const loginButton = document.getElementById('google-login-button');
       const loginButtonText = document.getElementById(
-        "google-login-button-text"
+        'google-login-button-text'
       );
 
       if (isLoggedIn) {
         showLogoutButton(logoutUrl);
-        document.getElementById("cta-area").innerHTML = `
+        document.getElementById('cta-area').innerHTML = `
           <a class="waves-effect white btn-large black-text" id="get-started-button" href="my-trips.html">Get Started</a>
         `;
       } else {
-        loginButton.setAttribute("href", loginUrl);
+        loginButton.setAttribute('href', loginUrl);
         const authRequiredLinks = document.getElementsByClassName(
-          "auth-required"
+          'auth-required'
         );
         Array.from(authRequiredLinks).forEach(
-          (element) => (element.style.display = "none")
+          (element) => (element.style.display = 'none')
         );
       }
     });

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -16,10 +16,10 @@ let markers;
  */
 function openTripEditor() {
   numLocations = 1;
-  locationPlaceObjects = [""];
+  locationPlaceObjects = [''];
   mapInitialized = false;
-  markers = [""];
-  document.getElementById("open-close-button-area").innerHTML = `
+  markers = [''];
+  document.getElementById('open-close-button-area').innerHTML = `
     <button
       onclick="cancelTripCreation()"
       class="btn-large add-trip-button waves-effect red darken-1"
@@ -27,7 +27,7 @@ function openTripEditor() {
       CANCEL
     </button>
   `;
-  document.getElementById("trip-editor-container").innerHTML = `
+  document.getElementById('trip-editor-container').innerHTML = `
     <div class="row">
       <div class="col s12 m8">
         <div class="card">
@@ -100,15 +100,15 @@ function openTripEditor() {
     </div>
   `;
   // initialize tooltip for Add Location button
-  const tooltipElems = document.querySelectorAll(".tooltipped");
+  const tooltipElems = document.querySelectorAll('.tooltipped');
   const tooltipInstances = M.Tooltip.init(tooltipElems, undefined);
 
   // prevent page reload on form submit
-  const form = document.getElementById("trip-editor-form");
-  form.addEventListener("submit", (e) => e.preventDefault());
+  const form = document.getElementById('trip-editor-form');
+  form.addEventListener('submit', (e) => e.preventDefault());
 
   // add autocomplete through Places API for first location
-  const location1 = document.getElementById("location-1");
+  const location1 = document.getElementById('location-1');
   const autocomplete = new google.maps.places.Autocomplete(location1);
   createPlaceHandler(autocomplete, 1);
 }
@@ -119,8 +119,8 @@ function openTripEditor() {
  */
 function addLocation() {
   numLocations++;
-  document.getElementById("trip-locations-container").insertAdjacentHTML(
-    "beforeend",
+  document.getElementById('trip-locations-container').insertAdjacentHTML(
+    'beforeend',
     `<div class="row">
       <div class="col s6">
         <label for="location-${numLocations}">Location ${numLocations}</label>
@@ -144,8 +144,8 @@ function addLocation() {
   const location = document.getElementById(`location-${numLocations}`);
   const autocomplete = new google.maps.places.Autocomplete(location);
   createPlaceHandler(autocomplete, numLocations);
-  markers.push("");
-  locationPlaceObjects.push("");
+  markers.push('');
+  locationPlaceObjects.push('');
 }
 
 /**
@@ -153,8 +153,8 @@ function addLocation() {
  * view.
  */
 function cancelTripCreation() {
-  document.getElementById("trip-editor-container").innerHTML = "";
-  document.getElementById("open-close-button-area").innerHTML = `
+  document.getElementById('trip-editor-container').innerHTML = '';
+  document.getElementById('open-close-button-area').innerHTML = `
     <button
       onclick="openTripEditor()"
       class="btn-large add-trip-button waves-effect green darken-1"
@@ -168,15 +168,15 @@ function cancelTripCreation() {
  * Opens modal with results for user to confirm and save trip.
  */
 async function findHotel() {
-  document.getElementById("hotel-results").innerHTML = LOADING_ANIMATION_HTML;
+  document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
   if (numLocations !== getNumPlaceObjectsInArray(locationPlaceObjects)) {
     M.Toast.dismissAll();
     M.toast({
-      html: "Not all of your places are selected through autocomplete.",
+      html: 'Not all of your places are selected through autocomplete.',
     });
     return;
   }
-  const elem = document.getElementById("hotel-modal");
+  const elem = document.getElementById('hotel-modal');
   const instance = M.Modal.getInstance(elem);
   instance.open();
 
@@ -197,17 +197,17 @@ async function findHotel() {
  *                      Places API for the centerpoint.
  */
 async function parseAndRenderHotelResults(json, centerPoint) {
-  const modalContent = document.getElementById("hotel-results");
-  const hotelsMapElem = document.getElementById("hotels-map");
-  hotelsMapElem.style.height = "";
-  hotelsMapElem.innerHTML = "";
+  const modalContent = document.getElementById('hotel-results');
+  const hotelsMapElem = document.getElementById('hotels-map');
+  hotelsMapElem.style.height = '';
+  hotelsMapElem.innerHTML = '';
   if (!json || json.length === 0) {
     modalContent.innerText =
       "We couldn't find any hotels nearby. Sorry about that.";
   } else {
     json = json.slice(0, 10);
     const hotelMap = new google.maps.Map(
-      document.getElementById("hotels-map"),
+      document.getElementById('hotels-map'),
       {
         center: centerPoint,
         zoom: 12,
@@ -233,14 +233,14 @@ async function parseAndRenderHotelResults(json, centerPoint) {
         map: hotelMap,
         title: obj.name,
         label: {
-          fontFamily: "Material Icons",
-          text: "hotel",
+          fontFamily: 'Material Icons',
+          text: 'hotel',
         },
       });
       const infoWindow = new google.maps.InfoWindow({
         content: `<h5 class="infowindow-text">${obj.name}</h5>`,
       });
-      marker.addListener("click", () => infoWindow.open(hotelMap, marker));
+      marker.addListener('click', () => infoWindow.open(hotelMap, marker));
       obj.distance_center = distanceBetween(location, centerPoint);
       const photoRef =
         obj.photos && Array.isArray(obj.photos)
@@ -252,16 +252,16 @@ async function parseAndRenderHotelResults(json, centerPoint) {
         obj.photo_ref = photoRef;
       } else {
         obj.photo_url = undefined;
-        obj.photo_ref = "";
+        obj.photo_ref = '';
       }
       return await obj;
     });
     json = await Promise.all(json);
     json.sort((a, b) => a.distance_center - b.distance_center);
 
-    hotelsMapElem.style.width = "100%";
-    hotelsMapElem.style.height = "400px";
-    hotelsMapElem.style.marginBottom = "2em";
+    hotelsMapElem.style.width = '100%';
+    hotelsMapElem.style.height = '400px';
+    hotelsMapElem.style.marginBottom = '2em';
     modalContent.innerHTML = json
       .map(
         ({ name, formatted_address, rating, place_id, photo_url, photo_ref }) =>
@@ -274,7 +274,7 @@ async function parseAndRenderHotelResults(json, centerPoint) {
                 <div class="card-image">
                   <img src="${photo_url}" alt="photo of ${name} from Google" loading="lazy" />
                 </div> `
-            : "") +
+            : '') +
           `
                 <div class="card-content black-text">
                   <span class="card-title"><strong>${name}</strong></span>
@@ -302,7 +302,7 @@ async function parseAndRenderHotelResults(json, centerPoint) {
           </div>
         `
       )
-      .join("");
+      .join('');
   }
 }
 
@@ -358,7 +358,7 @@ function degToRad(angle) {
  * @param {string} hotelName the name of the hotel
  */
 async function saveTrip(hotelID, hotelRef, hotelName) {
-  const elem = document.getElementById("hotel-modal");
+  const elem = document.getElementById('hotel-modal');
   const instance = M.Modal.getInstance(elem);
   instance.close();
 
@@ -374,7 +374,7 @@ async function saveTrip(hotelID, hotelRef, hotelName) {
   }
 
   const requestBody = {
-    title: document.getElementById("trip-title").value,
+    title: document.getElementById('trip-title').value,
     hotel_id: hotelID,
     hotel_img: hotelRef,
     hotel_name: hotelName,
@@ -382,10 +382,10 @@ async function saveTrip(hotelID, hotelRef, hotelName) {
     locations: locationData,
   };
 
-  await fetch("/trip-data", {
-    method: "POST",
+  await fetch('/trip-data', {
+    method: 'POST',
     headers: {
-      "content-type": "application/json",
+      'content-type': 'application/json',
     },
     body: JSON.stringify(requestBody),
   });
@@ -409,13 +409,13 @@ async function fetchAndRenderTripsFromDB() {
   `;
 
   const plannedTripsHTMLElement = document.getElementById(
-    "planned-trips-container"
+    'planned-trips-container'
   );
-  const pastTripsHTMLElement = document.getElementById("past-trips-container");
+  const pastTripsHTMLElement = document.getElementById('past-trips-container');
   plannedTripsHTMLElement.innerHTML = LOADING_ANIMATION_HTML;
   pastTripsHTMLElement.innerHTML = LOADING_ANIMATION_HTML;
-  const response = await fetch("/trip-data", {
-    method: "GET",
+  const response = await fetch('/trip-data', {
+    method: 'GET',
   });
   const tripsData = await response.json();
   const keys = Object.keys(tripsData);
@@ -428,8 +428,8 @@ async function fetchAndRenderTripsFromDB() {
     (a, b) =>
       parseSerializedJson(b).timestamp - parseSerializedJson(a).timestamp
   );
-  plannedTripsHTMLElement.innerHTML = "";
-  pastTripsHTMLElement.innerHTML = "";
+  plannedTripsHTMLElement.innerHTML = '';
+  pastTripsHTMLElement.innerHTML = '';
   console.log(tripsData);
   let isPlannedTripsEmpty = true;
   let isPastTripsEmpty = true;
@@ -447,7 +447,7 @@ async function fetchAndRenderTripsFromDB() {
     } = parseSerializedJson(key);
     const locations = tripsData[key];
     let HTMLElementToUpdate;
-    if (isPastTrip === "true") {
+    if (isPastTrip === 'true') {
       isPastTripsEmpty = false;
       HTMLElementToUpdate = pastTripsHTMLElement;
     } else {
@@ -492,7 +492,7 @@ async function fetchAndRenderTripsFromDB() {
           </div>
         `;
       })
-      .join("");
+      .join('');
   }
 
   // Iterate through keys again to load the map for each trip
@@ -517,8 +517,8 @@ async function fetchAndRenderTripsFromDB() {
           map: tripMap,
           position: location,
           label: {
-            fontFamily: "Material Icons",
-            text: "hotel",
+            fontFamily: 'Material Icons',
+            text: 'hotel',
           },
         });
         tripMarkers.push(marker);
@@ -527,7 +527,7 @@ async function fetchAndRenderTripsFromDB() {
           content: `<h5 class="infowindow-text">${name}</h5>
               <p class="infowindow-text">Hotel for Trip</p>`,
         });
-        google.maps.event.addListener(marker, "click", () => {
+        google.maps.event.addListener(marker, 'click', () => {
           infoWindow.open(tripMap, marker);
         });
         tripMap.fitBounds(viewport);
@@ -536,7 +536,7 @@ async function fetchAndRenderTripsFromDB() {
           <p>${formatted_address}</p>` +
           (website != undefined
             ? `<div class="card-action center"><a class="btn indigo waves-effect" href="${website}" target="_blank">Website</a></div>`
-            : "");
+            : '');
       }
     });
 
@@ -555,7 +555,7 @@ async function fetchAndRenderTripsFromDB() {
           const infoWindow = new google.maps.InfoWindow({
             content: `<h5 class="infowindow-text">${placeName}</h5>`,
           });
-          google.maps.event.addListener(placeMarker, "click", () => {
+          google.maps.event.addListener(placeMarker, 'click', () => {
             infoWindow.open(tripMap, placeMarker);
           });
           tripMap.fitBounds(viewport);
@@ -580,7 +580,7 @@ async function fetchAndRenderTripsFromDB() {
  * @param {number} locationNum the number identifying the field
  */
 function createPlaceHandler(element, locationNum) {
-  google.maps.event.addListener(element, "place_changed", () => {
+  google.maps.event.addListener(element, 'place_changed', () => {
     const obj = element.getPlace();
     obj.locationNum = locationNum;
     locationPlaceObjects[locationNum - 1] = obj;
@@ -592,13 +592,13 @@ function createPlaceHandler(element, locationNum) {
       lng: lng(),
     };
     if (!mapInitialized || locationNum === 1) {
-      map = new google.maps.Map(document.getElementById("editor-map"), {
+      map = new google.maps.Map(document.getElementById('editor-map'), {
         center: coords,
         zoom: 13,
       });
       mapInitialized = true;
     }
-    if (markers[locationNum - 1] !== "") {
+    if (markers[locationNum - 1] !== '') {
       const currMarkerForLocation = markers[locationNum - 1];
       currMarkerForLocation.setMap(null);
     }
@@ -612,7 +612,7 @@ function createPlaceHandler(element, locationNum) {
       content: `<h5 class="infowindow-text">${obj.name}</h5>
           <p class="infowindow-text">Location ${locationNum}</p>`,
     });
-    marker.addListener("click", () => infoWindow.open(map, marker));
+    marker.addListener('click', () => infoWindow.open(map, marker));
     markers[locationNum - 1] = marker;
     if (locationNum !== 1) {
       fitMapToMarkers(map, markers);
@@ -629,7 +629,7 @@ function createPlaceHandler(element, locationNum) {
 function fitMapToMarkers(mapRef, markers) {
   const bounds = new google.maps.LatLngBounds(null);
   for (marker of markers) {
-    if (marker !== "") {
+    if (marker !== '') {
       bounds.extend(marker.getPosition());
     }
   }

--- a/src/main/webapp/scripts/trips-network.js
+++ b/src/main/webapp/scripts/trips-network.js
@@ -8,58 +8,58 @@ function init() {
 
 const SAMPLE_POSTS_DATA = [
   {
-    title: "Amazing SF Trip",
+    title: 'Amazing SF Trip',
     destinations: [
       {
-        name: "Golden Gate Bridge",
+        name: 'Golden Gate Bridge',
       },
       {
         name: "Fisherman's Wharf",
       },
     ],
-    owner: "CoolGuy123",
+    owner: 'CoolGuy123',
     description:
-      "Great trip in SF, had a lot of fun. Lorem ipsum dolor sit amet.",
+      'Great trip in SF, had a lot of fun. Lorem ipsum dolor sit amet.',
     timestamp: 1593466864528,
-    hotel: "Hotel Inn San Fransisco",
+    hotel: 'Hotel Inn San Fransisco',
     rating: 4.5,
   },
   {
-    title: "Very Very Good Trip",
+    title: 'Very Very Good Trip',
     destinations: [
       {
-        name: "Empire State Building",
+        name: 'Empire State Building',
       },
       {
-        name: "SoHo",
+        name: 'SoHo',
       },
       {
-        name: "High Line",
+        name: 'High Line',
       },
     ],
-    owner: "HappyGuy",
-    description: "Great trip. Not much else to say.",
+    owner: 'HappyGuy',
+    description: 'Great trip. Not much else to say.',
     timestamp: 1583466733528,
-    hotel: "Luxury Hotel New York",
+    hotel: 'Luxury Hotel New York',
     rating: 5,
   },
   {
     title: "Don't Go Here",
     destinations: [
       {
-        name: "Bad Place #1",
+        name: 'Bad Place #1',
       },
       {
-        name: "Bad Place #2",
+        name: 'Bad Place #2',
       },
       {
-        name: "Bad Place #3",
+        name: 'Bad Place #3',
       },
     ],
-    owner: "BadGuy123",
+    owner: 'BadGuy123',
     description: "Don't do this. I had a horrible time.",
     timestamp: 1592466864528,
-    hotel: "Bad Hotel",
+    hotel: 'Bad Hotel',
     rating: 1,
   },
 ];
@@ -74,7 +74,7 @@ function loadSharedTripsData() {
   // function is not yet async, this part of the code is not visible since
   // the loading is negligible with constant preloaded data
   document.getElementById(
-    "shared-trips-section"
+    'shared-trips-section'
   ).innerHTML = LOADING_ANIMATION_HTML;
 
   // Sort posts with newest first
@@ -82,7 +82,7 @@ function loadSharedTripsData() {
 
   // Once data is loaded, render them into cards that display the data readably
   document.getElementById(
-    "shared-trips-section"
+    'shared-trips-section'
   ).innerHTML = SAMPLE_POSTS_DATA.map(
     ({ title, destinations, owner, description, timestamp, hotel, rating }) => `
         <div class="col m12 shared-trip-card">
@@ -111,11 +111,11 @@ function loadSharedTripsData() {
                       </li>
                     `
                   )
-                  .join(" ")}
+                  .join(' ')}
                 </ul>
             </div>
           </div>
         </div>
       `
-  ).join(" ");
+  ).join(' ');
 }

--- a/src/main/webapp/tests/constant-script.test.js
+++ b/src/main/webapp/tests/constant-script.test.js
@@ -1,37 +1,37 @@
-describe("Test the serialized by Gson JSON parser", () => {
-  it("parses an empty JSON string correctly", () => {
-    expect(parseSerializedJson("")).toEqual({});
+describe('Test the serialized by Gson JSON parser', () => {
+  it('parses an empty JSON string correctly', () => {
+    expect(parseSerializedJson('')).toEqual({});
   });
 
-  it("parses a single field JSON string correctly", () => {
-    expect(parseSerializedJson("{field1=yes}")).toEqual({
-      field1: "yes",
+  it('parses a single field JSON string correctly', () => {
+    expect(parseSerializedJson('{field1=yes}')).toEqual({
+      field1: 'yes',
     });
   });
 
-  it("parses an example value class with Gson correctly", () => {
+  it('parses an example value class with Gson correctly', () => {
     expect(
-      parseSerializedJson("AutoValue{prop1=5, prop2=yes, prop3=nope}")
+      parseSerializedJson('AutoValue{prop1=5, prop2=yes, prop3=nope}')
     ).toEqual({
-      prop1: "5",
-      prop2: "yes",
-      prop3: "nope",
+      prop1: '5',
+      prop2: 'yes',
+      prop3: 'nope',
     });
   });
 
-  it("parses Trip serialized JSON correctly", () => {
+  it('parses Trip serialized JSON correctly', () => {
     expect(
       parseSerializedJson(
-        "Trip{title=test, hotel=hotel1234, rating=-1.0, description=, owner=test@example.com, isPublic=false, timestamp=1594256985924}"
+        'Trip{title=test, hotel=hotel1234, rating=-1.0, description=, owner=test@example.com, isPublic=false, timestamp=1594256985924}'
       )
     ).toEqual({
-      description: "",
-      hotel: "hotel1234",
-      isPublic: "false",
-      owner: "test@example.com",
-      rating: "-1.0",
-      timestamp: "1594256985924",
-      title: "test",
+      description: '',
+      hotel: 'hotel1234',
+      isPublic: 'false',
+      owner: 'test@example.com',
+      rating: '-1.0',
+      timestamp: '1594256985924',
+      title: 'test',
     });
   });
 });

--- a/src/main/webapp/tests/my-trips.test.js
+++ b/src/main/webapp/tests/my-trips.test.js
@@ -1,10 +1,10 @@
-describe("Test center of mass function", () => {
-  it("Computes a singleton point correctly", () => {
+describe('Test center of mass function', () => {
+  it('Computes a singleton point correctly', () => {
     const singletonPointArray = [{ lat: 0, lng: 0, weight: 1 }];
     expectToBeCloseToArray(centerOfMass(singletonPointArray), [0, 0]);
   });
 
-  it("Computes an example set of points with weights correctly", () => {
+  it('Computes an example set of points with weights correctly', () => {
     const example1 = [
       {
         lat: 54.1,

--- a/src/main/webapp/tests/trips-network.test.js
+++ b/src/main/webapp/tests/trips-network.test.js
@@ -1,7 +1,7 @@
-describe("Test unix timestamp toString converter", () => {
-  it("converts timestamps correctly", () => {
-    expect(unixTimestampToString(1593466864528)).toBe("6/29/2020");
-    expect(unixTimestampToString(1593620880101)).toBe("7/1/2020");
-    expect(unixTimestampToString(946752900000)).toBe("1/1/2000");
+describe('Test unix timestamp toString converter', () => {
+  it('converts timestamps correctly', () => {
+    expect(unixTimestampToString(1593466864528)).toBe('6/29/2020');
+    expect(unixTimestampToString(1593620880101)).toBe('7/1/2020');
+    expect(unixTimestampToString(946752900000)).toBe('1/1/2000');
   });
 });


### PR DESCRIPTION
### Summary 
This PR fixes a code style issue noted by Miguel in #21. Currently, I use Prettier as my code formatter, and they automatically replace all single quotes with double quotes. I made a new Prettier configuration file that allows us to still conform to the Google JS Style Guide and still use Prettier. You can download and use it here: https://gist.github.com/ptwu/9fa8192b3df1df6d1d7c08334cf7c9fa

### Screenshot
N/A

### Test Plan
Run `mvn package appengine:run` in the root directory on Cloud Shell. See that there should be feature parity and no regressions in the functionality of the code.

All tests pass.

### Notes
I did not change the doublequotes in `itinerary-overview.js` to best avoid merge conflicts. We can handle that later, or @JoshLew7 can fix in his current branch.