### PR TITLE
My Trips CRUD operations support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
       <version>1.9.60</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>28.0-jre</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/sps/servlets/TripsServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripsServlet.java
@@ -5,6 +5,7 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.datastore.TransactionOptions;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.users.UserService;
@@ -98,7 +99,8 @@ public class TripsServlet extends HttpServlet {
     Entity tripEntity = convertTripToEntity(trip);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Transaction txn = datastore.beginTransaction();
+    TransactionOptions options = TransactionOptions.Builder.withXG(true);
+    Transaction txn = datastore.beginTransaction(options);
     try {
       datastore.put(txn, tripEntity);
 
@@ -135,7 +137,8 @@ public class TripsServlet extends HttpServlet {
     Entity tripEntity = convertTripToEntity(trip);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Transaction txn = datastore.beginTransaction();
+    TransactionOptions options = TransactionOptions.Builder.withXG(true);
+    Transaction txn = datastore.beginTransaction(options);
     try {
       Query tripQuery = new Query("trip")
                         .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail))

--- a/src/main/java/com/google/sps/servlets/TripsServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripsServlet.java
@@ -129,14 +129,14 @@ public class TripsServlet extends HttpServlet {
       Query tripLocationsQuery = new Query("trip-location")
                                   .setAncestor(existingTrip.getKey());
       Iterable<Entity> tripLocationEntityIterable = datastore.prepare(tripLocationsQuery).asIterable();
-      
+ 
       // delete current data relating to Trip
       datastore.delete(existingTrip.getKey());
       for (Entity tripLocationEntity : tripLocationEntityIterable) {
         datastore.delete(tripLocationEntity.getKey());
       }
     }
-
+    datastore.put(tripEntity);
     // build TripLocation objects from request data and put them in Datastore
     JsonArray locationData = jsonObject.getAsJsonArray("locations");
     Iterator<JsonElement> locationIterator = locationData.iterator();

--- a/src/main/java/com/google/sps/util/AuthChecker.java
+++ b/src/main/java/com/google/sps/util/AuthChecker.java
@@ -1,0 +1,27 @@
+package com.google.sps.util;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+
+public class AuthChecker {
+
+  /**
+   * Gets the email of the user accessing a certain endpoint.
+   * 
+   * @param response the calling servlet's response object to be updated in the
+   *                 case that the user is not authenticated
+   * @return the user's email as a String, or if the user is not logged in then
+   *         null.
+   */
+  public static String getUserEmail(HttpServletResponse response) {
+    UserService userService = UserServiceFactory.getUserService();
+    if (userService.isUserLoggedIn()) {
+      return userService.getCurrentUser().getEmail();
+    } else {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/google/sps/util/BodyParser.java
+++ b/src/main/java/com/google/sps/util/BodyParser.java
@@ -1,0 +1,24 @@
+package com.google.sps.util;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class BodyParser {
+
+  /**
+   * Parses the request body of a certain HTTP request using the Java Servlet framework
+   * and converts it into a Gson JsonObject.
+   * @param request a request passed to a certain servlet
+   * @return JsonObject with corresponding properties to the request body.
+   * @throws IOException
+   */
+  public static JsonObject parseJsonObjectFromRequest(HttpServletRequest request) throws IOException {
+    String requestBody = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
+    return JsonParser.parseString(requestBody).getAsJsonObject();
+  }
+}

--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -75,6 +75,16 @@
           <a href="#!" class="modal-close waves-effect btn-flat">Cancel</a>
         </div>
       </div>
+      <div id="delete-modal" class="modal">
+        <div class="modal-content">
+          <h4>Confirm Trip Deletion</h4>
+          <p>This will permanently delete this trip and saved information about it.</p>
+        </div>
+        <div class="modal-footer">
+          <a href="#!" class="modal-close waves-effect btn-flat">Cancel</a>
+          <a href="#!" id="modal-delete-btn" class="modal-close waves-effect btn-flat">Delete</a>
+        </div>
+      </div>
       <div class="row">
         <div class="col m10">
           <h3>My Trips</h3>

--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -78,11 +78,19 @@
       <div id="delete-modal" class="modal">
         <div class="modal-content">
           <h4>Confirm Trip Deletion</h4>
-          <p>This will delete this trip and saved information about it <strong>permanently.</strong></p>
+          <p>
+            This will delete this trip and saved information about it
+            <strong>permanently.</strong>
+          </p>
         </div>
         <div class="modal-footer">
           <a href="#!" class="modal-close waves-effect btn-flat">Cancel</a>
-          <a href="#!" id="modal-delete-btn" class="modal-close waves-effect btn-flat">Delete</a>
+          <a
+            href="#!"
+            id="modal-delete-btn"
+            class="modal-close waves-effect btn-flat"
+            >Delete</a
+          >
         </div>
       </div>
       <div class="row">
@@ -91,7 +99,7 @@
         </div>
         <div class="col m2" id="open-close-button-area">
           <button
-            onclick="openTripEditor()"
+            onclick="openTripEditor(null, null)"
             class="btn-large add-trip-button waves-effect green darken-1"
           >
             ADD TRIP

--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -99,7 +99,7 @@
         </div>
         <div class="col m2" id="open-close-button-area">
           <button
-            onclick="openTripEditor(null, null)"
+            onclick="openTripEditor(null, null, null)"
             class="btn-large add-trip-button waves-effect green darken-1"
           >
             ADD TRIP

--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -78,7 +78,7 @@
       <div id="delete-modal" class="modal">
         <div class="modal-content">
           <h4>Confirm Trip Deletion</h4>
-          <p>This will permanently delete this trip and saved information about it.</p>
+          <p>This will delete this trip and saved information about it <strong>permanently.</strong></p>
         </div>
         <div class="modal-footer">
           <a href="#!" class="modal-close waves-effect btn-flat">Cancel</a>

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -141,11 +141,11 @@ function openTripEditor(timestamp, locationData, title) {
           </div>
           <div class="col s6">
             <p class="range-field weight-slider">
-              <label for="location-${numLocations}-weight">Weight</label>
+              <label for="location-${i}-weight">Weight</label>
               <input
                 type="range"
-                name="location-${numLocations}-weight"
-                id="location-${numLocations}-weight"
+                name="location-${i}-weight"
+                id="location-${i}-weight"
                 min="1"
                 value="${locationData[i - 1].weight}
                 max="5"
@@ -169,7 +169,7 @@ function openTripEditor(timestamp, locationData, title) {
           if (!mapInitialized) {
             map = new google.maps.Map(document.getElementById('editor-map'), {
               center: location,
-              zoom: 15,
+              zoom: 13,
             });
             mapInitialized = true;
           }
@@ -177,6 +177,7 @@ function openTripEditor(timestamp, locationData, title) {
             map: map,
             position: location,
           });
+          place.locationNum = index + 1;
           locationPlaceObjects.push(place);
           markers.push(marker);
           const infoWindow = new google.maps.InfoWindow({
@@ -192,6 +193,8 @@ function openTripEditor(timestamp, locationData, title) {
     });
     
   }
+  console.log(locationPlaceObjects);
+  console.log(markers);
   // initialize tooltip for Add Location button
   const tooltipElems = document.querySelectorAll('.tooltipped');
   const tooltipInstances = M.Tooltip.init(tooltipElems, undefined);
@@ -781,8 +784,6 @@ function createPlaceHandler(element, locationNum) {
       fitMapToMarkers(map, markers);
       map.setZoom(map.getZoom() - 0.3);
     }
-    console.log(markers);
-    console.log(locationPlaceObjects);
   });
 }
 

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -136,9 +136,9 @@ function openTripEditor(timestamp, locationData, title) {
         'beforeend',
         `<div class="row">
           <div class="col s6">
-            <label for="location-${numLocations}">Location ${numLocations}</label>
+            <label for="location-${i}">Location ${i}</label>
             <input 
-              id="location-${numLocations}" 
+              id="location-${i}" 
               type="text" 
               value="${locationData[i - 1].placeName}"
             />
@@ -280,6 +280,9 @@ async function findHotel(timestamp) {
   // Get center point from which to start searching for hotels
   const coords = placesToCoordsWeightArray(locationPlaceObjects);
   const [lat, lng] = centerOfMass(coords);
+  document.getElementById('hotels-map').innerHTML = '';
+  document.getElementById('hotels-map').style.display = 'none';
+
   const response = await fetch(
     `https://cors-anywhere.herokuapp.com/https://maps.googleapis.com/maps/api/place/textsearch/json?type=lodging&location=${lat},${lng}&radius=10000&key=${GOOGLE_API_KEY}&output=json`
   );
@@ -299,7 +302,7 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
   const modalContent = document.getElementById('hotel-results');
   const hotelsMapElem = document.getElementById('hotels-map');
   hotelsMapElem.style.height = '';
-  hotelsMapElem.innerHTML = '';
+ 
   if (!json || json.length === 0) {
     modalContent.innerText =
       "We couldn't find any hotels nearby. Sorry about that.";
@@ -357,7 +360,8 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
     });
     json = await Promise.all(json);
     json.sort((a, b) => a.distance_center - b.distance_center);
-
+    
+    hotelsMapElem.style.width = '100%';
     hotelsMapElem.style.width = '100%';
     hotelsMapElem.style.height = '400px';
     hotelsMapElem.style.marginBottom = '2em';
@@ -782,10 +786,11 @@ function createPlaceHandler(element, locationNum) {
       lat: lat(),
       lng: lng(),
     };
-    if (!mapInitialized || locationNum === 1) {
+    if (!mapInitialized) {
       map = new google.maps.Map(document.getElementById('editor-map'), {
         center: coords,
         zoom: 13,
+        disableDefaultUI: true,
       });
       mapInitialized = true;
     }

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -386,7 +386,7 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
                     onClick="saveTrip('${place_id}', 
                                       '${photo_ref}', 
                                       '${name.replace(/'/g, "\\'")}',
-                                      '${timestamp}')"
+                                       ${timestamp})"
                   >
                     CHOOSE
                   </button>
@@ -459,8 +459,8 @@ function degToRad(angle) {
  * @param {string} hotelID  the Place ID for the hotel
  * @param {string} hotelRef the photo reference in Google Place Photos for the hotel.
  * @param {string} hotelName the name of the hotel
- * @param {string|null} timestamp timestamp string of the trip to be updated.
- *                                Null if this is a new trip.
+ * @param {string|null|undefined} timestamp timestamp string of the trip to be updated.
+ *                                          Null/undefined if this is a new trip.
  */
 async function saveTrip(hotelID, hotelRef, hotelName, timestamp) {
   const elem = document.getElementById('hotel-modal');
@@ -487,10 +487,12 @@ async function saveTrip(hotelID, hotelRef, hotelName, timestamp) {
     rating: -1,
     locations: locationData,
   };
+  console.log(timestamp);
 
-  if (timestamp !== null) {
+  if (timestamp) {
     requestBody.timestamp = timestamp;
   }
+  console.log(requestBody);
 
   const response = await fetch('/trip-data', {
     method: 'PUT',
@@ -500,7 +502,7 @@ async function saveTrip(hotelID, hotelRef, hotelName, timestamp) {
     body: JSON.stringify(requestBody),
   });
   if (response.ok) {
-    if (timestamp !== null) {
+    if (timestamp) {
       M.toast({
         html: `Successfully updated ${tripTitle}.`,
       });
@@ -625,14 +627,16 @@ async function fetchAndRenderTripsFromDB() {
                   <button 
                     type="button"
                     onclick="openDeleteModal('${timestamp}')"
-                    class="btn-floating btn-large indigo update-button waves-effect waves-light"
+                    class="btn-floating btn-large indigo update-button waves-effect waves-light tooltipped"
+                    data-tooltip="Delete trip"
                   >
                     <i class="large material-icons">delete</i>
                   </button>
                   <button 
                     type="button"
                     id="edit-button-${timestamp}"
-                    class="btn-floating btn-large indigo update-button waves-effect waves-light"
+                    class="btn-floating btn-large indigo update-button waves-effect waves-light tooltipped"
+                    data-tooltip="Edit trip info"
                   >
                     <i class="large material-icons">mode_edit</i>
                   </button>
@@ -656,7 +660,9 @@ async function fetchAndRenderTripsFromDB() {
         </div>
       </div>
     `;
-    
+    // initialize tooltips for edit and delete trip buttons
+    const tooltipElems = document.querySelectorAll('.tooltipped');
+    const tooltipInstances = M.Tooltip.init(tooltipElems, undefined);
     document.getElementById(`trip-${timestamp}-locations`).innerHTML = locations
       .map(({ weight, placeName }, index) => {
         return `

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -154,7 +154,6 @@ function openTripEditor(timestamp, locationData) {
       createPlaceHandler(autocomplete, i);
     }
     locationPlaceObjects = [''];
-    mapInitialized = false;
     markers = [''];
   }
   // initialize tooltip for Add Location button

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -275,15 +275,15 @@ async function parseAndRenderHotelResults(json, centerPoint) {
                   <img src="${photo_url}" alt="photo of ${name} from Google" loading="lazy" />
                 </div> `
             : '') +
-          `
+              `
                 <div class="card-content black-text">
                   <span class="card-title"><strong>${name}</strong></span>
                   <p>${formatted_address}</p>
                 </div>
                 <div class="card-action center">
-                  <button 
+                  <button
                     class="btn indigo" 
-                    onClick="saveTrip('${place_id}', '${photo_ref}', '${name}')"
+                    onClick="saveTrip('${place_id}', '${photo_ref}', '${name.replace(/'/g, "\\'")}')"
                   >
                     CHOOSE
                   </button>

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -122,7 +122,7 @@ function openTripEditor(timestamp, locationData, title) {
     locationPlaceObjects = [];
     markers = [];
     numLocations = locationData.length;
-    
+
     mapInitialized = false;
     // Populate frontend fields with existing data
     document.getElementById('trip-title').value = title;
@@ -198,7 +198,6 @@ function openTripEditor(timestamp, locationData, title) {
       });
     });
   }
-
 
   // initialize tooltip for Add Location button
   const tooltipElems = document.querySelectorAll('.tooltipped');
@@ -751,11 +750,11 @@ async function fetchAndRenderTripsFromDB() {
         }
       });
     });
-    
+
     // Give edit buttons for each trip functionality
     document.getElementById(`edit-button-${timestamp}`).onclick = () => {
       openTripEditor(`${timestamp}`, locations, `${title}`);
-      window.scrollTo(0, 0); 
+      window.scrollTo(0, 0);
     };
   }
 

--- a/src/main/webapp/styles/my-trips.css
+++ b/src/main/webapp/styles/my-trips.css
@@ -11,7 +11,15 @@
   font-size: 18px;
 }
 
+.trip-title-section {
+  margin-left: 0 !important;
+}
+
 .trip-map {
   min-height: 300px;
   width: 100%;
+}
+
+.update-button {
+  margin: 0 0.25em 0 0.25em;
 }


### PR DESCRIPTION
### Summary 
This PR implements extended support for the trip editor, by adding an "Edit" option for each trip. There is also a "Delete" option that allows you to remove a trip and its associated locations from the DB entirely. 

I found that a `PUT` request was more suitable for our updating endpoint in `/trip-data` rather than `POST` since `PUT` requests are defined as _idempotent_; subsequent calls of a `PUT` request will have no side effects since the first one other than overwriting it. This allowed me to define the `PUT` request to accept a request body where it contains a `timestamp` field, and the trip corresponding to that timestamp is getting updated with the request body's values.

Implementing the Trip Editor for updating trips required some significant work in getting the fields to be pre-filled with existing trip data, as well as the Google Map. To "simulate" the autocomplete being filled out for every single field in the update editor, I added to the `markers` and `locationPlaceObjects` arrays, which is how I normally keep track of whether each item is filled out in the autocomplete. This led to an unnoticeable difference for the end-user.

### Screenshot
![screen](https://user-images.githubusercontent.com/7517829/88122951-ddce3380-cb97-11ea-80ae-af126005639d.gif)

### Test Plan
Run `mvn package appengine:run`. Add a new trip and see that this functionality is preserved. Edit this trip and add another location / choose a different hotel / change weights around. See that the page changes. Try deleting the trip and see that you now have no trips.

More thorough unit tests will be implemented soon using Mockito.

### Notes
There is still no support for deleting locations from a trip. This should be mainly frontend-focused since we just replace the entire trip rather than upserting, and will come in a later PR.