### PR TITLE
Finalize trip editor: Add deletion + more tooltips

### DIFF
--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -376,8 +376,6 @@ function cancelTripCreation() {
 async function findHotel(timestamp) {
   document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
   if (numLocations !== getNumPlaceObjectsInArray(locationPlaceObjects)) {
-    console.log('Num Locations ' + numLocations);
-    console.log('location place obj # ' + getNumPlaceObjectsInArray(locationPlaceObjects));
     M.Toast.dismissAll();
     M.toast({
       html: 'Not all of your places are selected through autocomplete.',

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -161,7 +161,11 @@ function openTripEditor(timestamp, locationData, title) {
             </p>
           </div>
            <div class="col s3 m1">
-            <a class="btn-floating indigo waves-effect" onclick="deleteLocation(${i})">
+            <a 
+              id="location-${i}-delete"
+              class="btn-floating indigo waves-effect" 
+              onclick="deleteLocation(${i})"
+            >
               <i class="material-icons">remove_circle</i>
             </a>
           </div>
@@ -242,7 +246,11 @@ function addLocation() {
         </p>
       </div>
       <div class="col s3 m1">
-        <a class="btn-floating indigo waves-effect" onclick="deleteLocation(${numLocations})">
+        <a 
+          id="location-${numLocations}-delete"
+          class="btn-floating indigo waves-effect" 
+          onclick="deleteLocation(${numLocations})"
+        >
           <i class="material-icons">remove_circle</i>
         </a>
       </div>
@@ -263,26 +271,42 @@ function addLocation() {
  */
 function deleteLocation(locationNum) {
   console.log(markers);
-  console.log("yeet " + locationNum);
   if (locationNum > markers.length || locationNum < 1) {
     throw new Error("Cannot delete invalid location");
   }
   const index = locationNum - 1;
   // Remove trip from DOM and shift following trip location nums down 1
-  const elem = document.querySelector(`trip-${locationNum}-container`);
-  elem.parentNode.removeChild(elem);
+  const elem = document.getElementById(`location-${locationNum}-container`);
+  elem.parentElement.removeChild(elem);
   for (let i = locationNum + 1; i <= numLocations; i++) {
-    const label = document.getElementById(`location-${i}-label`);
+    const locationContainer = document.getElementById(`location-${i}-container`);
+    const locationLabel = document.getElementById(`location-${i}-label`);
+    const location = document.getElementById(`location-${i}`);
     const weightLabel = document.getElementById(`location-${i}-weight-label`);
-    
+    const weight = document.getElementById(`location-${i}-weight`);
+    const deleteButton = document.getElementById(`location-${i}-delete`);
+    const locationShift = `location-${i - 1}`;
+   
+    locationContainer.id = `${locationShift}-container`;
+    locationLabel.id = `${locationShift}-label`;
+    location.id = `${locationShift}`;
+    weightLabel.id = `${locationShift}-weight-label`;
+    weight.id = `${locationShift}-weight`;
+    deleteButton.id = `${locationShift}-delete`;
+    locationLabel.innerText = `Location ${i - 1}`;
+    locationLabel.htmlFor = `${locationShift}`;
+    deleteButton.onclick = () => deleteLocation(i - 1);
   }
 
   // Remove marker from map and also the array
-  markers[index].setMap(null);
+  if (markers[index] !== '') {
+    markers[index].setMap(null);
+  }
+  numLocations--;
   markers.splice(index, 1);
   fitMapToMarkers(map, markers);
   locationPlaceObjects.splice(index, 1);
-  numLocations--;
+  console.log(markers);
 }
 
 /**

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -12,6 +12,7 @@ let numLocations;
 let locationPlaceObjects;
 let mapInitialized;
 let markers;
+
 /**
  * Adds a trip editor interface to the DOM, which the user can use to add a trip.
  * @param {string|null} timestamp timestamp string of the trip to be updated.
@@ -48,11 +49,11 @@ function openTripEditor(timestamp, locationData, title) {
             <form id="trip-editor-form">
               <div id="trip-locations-container">
                 <div class="row">
-                  <div class="col s6">
+                  <div class="col s12 m6">
                     <label for="location-1">Location 1</label>
                     <input id="location-1" type="text" required />
                   </div>
-                  <div class="col s6">
+                  <div class="col s9 m5">
                     <p class="range-field weight-slider">
                       <label for="location-1-weight">Weight</label>
                       <input
@@ -65,6 +66,7 @@ function openTripEditor(timestamp, locationData, title) {
                       />
                     </p>
                   </div>
+                   
                 </div>
               </div>
               <div class="row">
@@ -135,18 +137,18 @@ function openTripEditor(timestamp, locationData, title) {
     for (let i = 2; i <= numLocations; i++) {
       document.getElementById('trip-locations-container').insertAdjacentHTML(
         'beforeend',
-        `<div class="row">
-          <div class="col s6">
-            <label for="location-${i}">Location ${i}</label>
+        `<div class="row" id="location-${i}-container">
+          <div class="col s12 m6">
+            <label for="location-${i}" id="location-${i}-label">Location ${i}</label>
             <input 
               id="location-${i}" 
               type="text" 
               value="${locationData[i - 1].placeName}"
             />
           </div>
-          <div class="col s6">
+          <div class="col s9 m5">
             <p class="range-field weight-slider">
-              <label for="location-${i}-weight">Weight</label>
+              <label for="location-${i}-weight" id="location-${i}-weight-label">Weight</label>
               <input
                 type="range"
                 name="location-${i}-weight"
@@ -157,6 +159,11 @@ function openTripEditor(timestamp, locationData, title) {
                 step="1"
               />
             </p>
+          </div>
+           <div class="col s3 m1">
+            <a class="btn-floating indigo waves-effect" onclick="deleteLocation(${i})">
+              <i class="material-icons">remove_circle</i>
+            </a>
           </div>
         </div>
         `
@@ -217,14 +224,14 @@ function addLocation() {
   numLocations++;
   document.getElementById('trip-locations-container').insertAdjacentHTML(
     'beforeend',
-    `<div class="row">
-      <div class="col s6">
-        <label for="location-${numLocations}">Location ${numLocations}</label>
+    `<div class="row" id="location-${numLocations}-container">
+      <div class="col s12 m6">
+        <label for="location-${numLocations}" id="location-${numLocations}-label">Location ${numLocations}</label>
         <input id="location-${numLocations}" type="text" />
       </div>
-      <div class="col s6">
+      <div class="col s9 m5">
         <p class="range-field weight-slider">
-          <label for="location-${numLocations}-weight">Weight</label>
+          <label for="location-${numLocations}-weight" id="location-${numLocations}-weight-label">Weight</label>
           <input
             type="range"
             name="location-${numLocations}-weight"
@@ -234,6 +241,11 @@ function addLocation() {
           />
         </p>
       </div>
+      <div class="col s3 m1">
+        <a class="btn-floating indigo waves-effect" onclick="deleteLocation(${numLocations})">
+          <i class="material-icons">remove_circle</i>
+        </a>
+      </div>
     </div>`
   );
   // add autocomplete through Places API for new location
@@ -242,6 +254,35 @@ function addLocation() {
   createPlaceHandler(autocomplete, numLocations);
   markers.push('');
   locationPlaceObjects.push('');
+}
+
+/**
+ * Deletes a location in a certain trip open in the Trip Editor.
+ * @param {number} locationNum number of location to be deleted
+ * @throws Will throw an error if the locationNum is invalid.
+ */
+function deleteLocation(locationNum) {
+  console.log(markers);
+  console.log("yeet " + locationNum);
+  if (locationNum > markers.length || locationNum < 1) {
+    throw new Error("Cannot delete invalid location");
+  }
+  const index = locationNum - 1;
+  // Remove trip from DOM and shift following trip location nums down 1
+  const elem = document.querySelector(`trip-${locationNum}-container`);
+  elem.parentNode.removeChild(elem);
+  for (let i = locationNum + 1; i <= numLocations; i++) {
+    const label = document.getElementById(`location-${i}-label`);
+    const weightLabel = document.getElementById(`location-${i}-weight-label`);
+    
+  }
+
+  // Remove marker from map and also the array
+  markers[index].setMap(null);
+  markers.splice(index, 1);
+  fitMapToMarkers(map, markers);
+  locationPlaceObjects.splice(index, 1);
+  numLocations--;
 }
 
 /**

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -55,7 +55,13 @@ function openTripEditor(timestamp, locationData, title) {
                   </div>
                   <div class="col s9 m5">
                     <p class="range-field weight-slider">
-                      <label for="location-1-weight">Weight</label>
+                      <label 
+                        for="location-1-weight"
+                        class="tooltipped"
+                        data-tooltip="Assign how close you want to be to this location"
+                      >
+                        Weight
+                      </label>
                       <input
                         type="range"
                         name="location-1-weight"
@@ -148,7 +154,14 @@ function openTripEditor(timestamp, locationData, title) {
           </div>
           <div class="col s9 m5">
             <p class="range-field weight-slider">
-              <label for="location-${i}-weight" id="location-${i}-weight-label">Weight</label>
+              <label 
+                for="location-${i}-weight" 
+                id="location-${i}-weight-label"
+                class="tooltipped"
+                data-tooltip="Assign how close you want to be to this location"
+              >
+                Weight
+              </label>
               <input
                 type="range"
                 name="location-${i}-weight"

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -293,26 +293,30 @@ function addLocation() {
  */
 function deleteLocation(locationNum) {
   if (locationNum > markers.length || locationNum < 1) {
-    throw new Error("Cannot delete invalid location");
+    throw new Error('Cannot delete invalid location');
   }
   const index = locationNum - 1;
   // Close current tooltip
-  const currDeleteButton = document.getElementById(`location-${locationNum}-delete`);
+  const currDeleteButton = document.getElementById(
+    `location-${locationNum}-delete`
+  );
   const instance = M.Tooltip.getInstance(currDeleteButton);
   instance.close();
-  
+
   // Remove trip from DOM and shift following trip location nums down 1
   const elem = document.getElementById(`location-${locationNum}-container`);
   elem.parentElement.removeChild(elem);
   for (let i = locationNum + 1; i <= numLocations; i++) {
-    const locationContainer = document.getElementById(`location-${i}-container`);
+    const locationContainer = document.getElementById(
+      `location-${i}-container`
+    );
     const locationLabel = document.getElementById(`location-${i}-label`);
     const location = document.getElementById(`location-${i}`);
     const weightLabel = document.getElementById(`location-${i}-weight-label`);
     const weight = document.getElementById(`location-${i}-weight`);
     const deleteButton = document.getElementById(`location-${i}-delete`);
     const locationShift = `location-${i - 1}`;
- 
+
     locationContainer.id = `${locationShift}-container`;
     locationLabel.id = `${locationShift}-label`;
     location.id = `${locationShift}`;

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -163,7 +163,8 @@ function openTripEditor(timestamp, locationData, title) {
            <div class="col s3 m1">
             <a 
               id="location-${i}-delete"
-              class="btn-floating indigo waves-effect" 
+              class="btn-floating indigo waves-effect tooltipped" 
+              data-tooltip="Delete this location"
               onclick="deleteLocation(${i})"
             >
               <i class="material-icons">remove_circle</i>
@@ -235,7 +236,14 @@ function addLocation() {
       </div>
       <div class="col s9 m5">
         <p class="range-field weight-slider">
-          <label for="location-${numLocations}-weight" id="location-${numLocations}-weight-label">Weight</label>
+          <label 
+            for="location-${numLocations}-weight" 
+            id="location-${numLocations}-weight-label"
+            class="tooltipped"
+            data-tooltip="Assign how close you want to be to this location"
+          >
+            Weight
+          </label>
           <input
             type="range"
             name="location-${numLocations}-weight"
@@ -248,7 +256,8 @@ function addLocation() {
       <div class="col s3 m1">
         <a 
           id="location-${numLocations}-delete"
-          class="btn-floating indigo waves-effect" 
+          class="btn-floating indigo waves-effect tooltipped"
+          data-tooltip="Delete this location" 
           onclick="deleteLocation(${numLocations})"
         >
           <i class="material-icons">remove_circle</i>
@@ -270,11 +279,15 @@ function addLocation() {
  * @throws Will throw an error if the locationNum is invalid.
  */
 function deleteLocation(locationNum) {
-  console.log(markers);
   if (locationNum > markers.length || locationNum < 1) {
     throw new Error("Cannot delete invalid location");
   }
   const index = locationNum - 1;
+  // Close current tooltip
+  const currDeleteButton = document.getElementById(`location-${locationNum}-delete`);
+  const instance = M.Tooltip.getInstance(currDeleteButton);
+  instance.close();
+  
   // Remove trip from DOM and shift following trip location nums down 1
   const elem = document.getElementById(`location-${locationNum}-container`);
   elem.parentElement.removeChild(elem);
@@ -286,7 +299,7 @@ function deleteLocation(locationNum) {
     const weight = document.getElementById(`location-${i}-weight`);
     const deleteButton = document.getElementById(`location-${i}-delete`);
     const locationShift = `location-${i - 1}`;
-   
+ 
     locationContainer.id = `${locationShift}-container`;
     locationLabel.id = `${locationShift}-label`;
     location.id = `${locationShift}`;


### PR DESCRIPTION
### Summary
This PR implements deletion of locations for existing trips using the Trip Editor, as well as useful tooltips for deletion and explaining weights to the user.

Deleting locations requires a cascading update for every following trip location, as we need to change the location numbers and update the markers on the map. These side effects required me to account for updating/removing markers from the editor map, splice the `markers` and `locationPlaceObjects` arrays, and remove event listeners that apply to locations that have changed number as a result of a deletion.

### Screenshot
**Tooltips for weight**
![Screenshot 2020-07-28 at 6 15 20 PM](https://user-images.githubusercontent.com/7517829/88727835-62700300-d0fe-11ea-9a13-5dba436871eb.png)

**Deletion feature**
![Overnightly _ My Trips (11)](https://user-images.githubusercontent.com/7517829/88728083-efb35780-d0fe-11ea-9a2e-153188f923e9.gif)

### Test Plan
Run `mvn package appengine:run`. Mouse over the "Weight" label to see that the tooltip works. Delete some locations in a preexisting trip and add some more, and see that the trip is updated accordingly.