### PR TITLE
Trips Network Backend + Frontend Alpha: mark trips as past trips, post trips, view trips

### DIFF
--- a/src/main/java/com/google/sps/servlets/TripsNetworkServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripsNetworkServlet.java
@@ -123,7 +123,7 @@ public class TripsNetworkServlet extends HttpServlet {
 
     Iterable<Entity> tripEntityIterable = datastore.prepare(tripQuery).asIterable();
 
-    if (Iterables.size(tripEntityIterable) == 0) {
+    if (Iterables.size(tripEntityIterable) == 0 || Iterables.size(tripEntityIterable) > 1) {
       response.setStatus(HttpServletResponse.SC_NOT_FOUND);
       return;
     }

--- a/src/main/java/com/google/sps/servlets/TripsNetworkServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripsNetworkServlet.java
@@ -1,0 +1,60 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.datastore.TransactionOptions;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.common.collect.Iterables;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.gson.Gson;
+import com.google.sps.data.AuthInfo;
+import com.google.sps.data.Trip;
+import com.google.sps.data.TripLocation;
+import com.google.sps.util.AuthChecker;
+import com.google.sps.util.TripDataConverter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/trips-network")
+public class TripsNetworkServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String userEmail = AuthChecker.getUserEmail(response);
+    if (userEmail == null) {
+      return;
+    }
+
+    Query tripQuery = new Query("trip")
+        .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_PAST_TRIP, FilterOperator.EQUAL, true));
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery tripResults = datastore.prepare(tripQuery);
+    Iterable<Entity> tripEntityIterable = tripResults.asIterable();
+    for (Entity entity : tripEntityIterable) {
+      Trip trip = TripDataConverter.convertEntityToTrip(entity);
+    }
+    List<Map<Key, List<TripLocation>>> tripLocationMapList = new ArrayList<>();
+    Query tripLocationsQuery = new Query("trip-location")
+        .setFilter(new FilterPredicate(TripLocation.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail));
+
+    response.setContentType("application/json");
+    Gson gson = new Gson();
+
+  }
+}

--- a/src/main/java/com/google/sps/servlets/TripsServlet.java
+++ b/src/main/java/com/google/sps/servlets/TripsServlet.java
@@ -8,8 +8,6 @@ import com.google.appengine.api.datastore.Transaction;
 import com.google.appengine.api.datastore.TransactionOptions;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
-import com.google.appengine.api.users.UserService;
-import com.google.appengine.api.users.UserServiceFactory;
 import com.google.common.collect.Iterables;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Key;
@@ -17,11 +15,11 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.sps.data.TripLocation;
 import com.google.sps.data.Trip;
 import com.google.sps.util.BodyParser;
 import com.google.sps.util.AuthChecker;
+import com.google.sps.util.TripDataConverter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +27,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -49,21 +46,22 @@ public class TripsServlet extends HttpServlet {
       return;
     }
     Query tripQuery = new Query("trip")
-                      .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail));
+        .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail));
     Query tripLocationsQuery = new Query("trip-location")
-                                .setFilter(new FilterPredicate(TripLocation.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail));
+        .setFilter(new FilterPredicate(TripLocation.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail));
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery tripResults = datastore.prepare(tripQuery);
     PreparedQuery tripLocationResults = datastore.prepare(tripLocationsQuery);
     Iterable<Entity> tripEntityIterable = tripResults.asIterable();
     Iterable<Entity> tripLocationEntityIterable = tripLocationResults.asIterable();
-    
-    // Convert trip location iterable to HashMap with mapping from timestamp to TripLocation object
+
+    // Convert trip location iterable to HashMap with mapping from timestamp to
+    // TripLocation object
     // Provides easy O(1) lookup of locations for a certain trip.
     Map<Key, List<TripLocation>> tripLocationMap = new HashMap<>();
-    for(Entity entity : tripLocationEntityIterable) {
-      TripLocation location = convertEntityToTripLocation(entity);
-      if(tripLocationMap.containsKey(entity.getParent())) {
+    for (Entity entity : tripLocationEntityIterable) {
+      TripLocation location = TripDataConverter.convertEntityToTripLocation(entity);
+      if (tripLocationMap.containsKey(entity.getParent())) {
         List<TripLocation> locationsUnderCurrTrip = tripLocationMap.get(entity.getParent());
         locationsUnderCurrTrip.add(location);
         tripLocationMap.replace(entity.getParent(), locationsUnderCurrTrip);
@@ -75,7 +73,7 @@ public class TripsServlet extends HttpServlet {
     // Get list of trips without their corresponding locations
     Map<Trip, List<TripLocation>> userTripsDataResponse = new HashMap<>();
     for (Entity entity : tripEntityIterable) {
-      Trip trip = convertEntityToTrip(entity);
+      Trip trip = TripDataConverter.convertEntityToTrip(entity);
       userTripsDataResponse.put(trip, tripLocationMap.get(entity.getKey()));
     }
 
@@ -83,7 +81,7 @@ public class TripsServlet extends HttpServlet {
     Gson gson = new Gson();
     String serializedJSON = gson.toJson(userTripsDataResponse);
     response.getWriter().println(serializedJSON);
-    response.setStatus(HttpServletResponse.SC_OK); 
+    response.setStatus(HttpServletResponse.SC_OK);
   }
 
   @Override
@@ -94,9 +92,9 @@ public class TripsServlet extends HttpServlet {
     }
     JsonObject jsonObject = BodyParser.parseJsonObjectFromRequest(request);
     long timestamp = System.currentTimeMillis();
-    
-    Trip trip = convertJsonObjectToTrip(jsonObject, userEmail, timestamp);
-    Entity tripEntity = convertTripToEntity(trip);
+
+    Trip trip = TripDataConverter.convertJsonObjectToTrip(jsonObject, userEmail, timestamp);
+    Entity tripEntity = TripDataConverter.convertTripToEntity(trip);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     TransactionOptions options = TransactionOptions.Builder.withXG(true);
@@ -107,11 +105,12 @@ public class TripsServlet extends HttpServlet {
       JsonArray locationData = jsonObject.getAsJsonArray("locations");
       Iterator<JsonElement> locationIterator = locationData.iterator();
 
-      while(locationIterator.hasNext()) {
-        TripLocation location = convertJsonObjectToTripLocation(locationIterator.next().getAsJsonObject(), userEmail);
-        datastore.put(txn, convertTripLocationToEntity(location, tripEntity));
-      };
-    
+      while (locationIterator.hasNext()) {
+        TripLocation location = TripDataConverter.convertJsonObjectToTripLocation(locationIterator.next().getAsJsonObject(), userEmail);
+        datastore.put(txn, TripDataConverter.convertTripLocationToEntity(location, tripEntity));
+      }
+      ;
+
       txn.commit();
     } finally {
       if (txn.isActive()) {
@@ -129,31 +128,32 @@ public class TripsServlet extends HttpServlet {
     if (userEmail == null) {
       return;
     }
-    
+
     JsonObject jsonObject = BodyParser.parseJsonObjectFromRequest(request);
     long timestamp = jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_TIMESTAMP).getAsLong();
-    
-    Trip trip = convertJsonObjectToTrip(jsonObject, userEmail, timestamp);
-    Entity tripEntity = convertTripToEntity(trip);
+
+    Trip trip = TripDataConverter.convertJsonObjectToTrip(jsonObject, userEmail, timestamp);
+    Entity tripEntity = TripDataConverter.convertTripToEntity(trip);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     TransactionOptions options = TransactionOptions.Builder.withXG(true);
     Transaction txn = datastore.beginTransaction(options);
     try {
       Query tripQuery = new Query("trip")
-                        .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail))
-                        .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_TIMESTAMP, FilterOperator.EQUAL, timestamp));
-      
+          .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail))
+          .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_TIMESTAMP, FilterOperator.EQUAL, timestamp));
+
       Iterable<Entity> tripEntityIterable = datastore.prepare(tripQuery).asIterable();
       if (Iterables.size(tripEntityIterable) == 0) {
-        /* If we reach this breakpoint, that means no Trip matches the timestamp 
-            to be updated. Send back an error code 404. */
+        /*
+         * If we reach this breakpoint, that means no Trip matches the timestamp to be
+         * updated. Send back an error code 404.
+         */
         response.setStatus(HttpServletResponse.SC_NOT_FOUND);
         return;
       }
       Entity existingTrip = tripEntityIterable.iterator().next();
-      Query tripLocationsQuery = new Query("trip-location")
-                                  .setAncestor(existingTrip.getKey());
+      Query tripLocationsQuery = new Query("trip-location").setAncestor(existingTrip.getKey());
       Iterable<Entity> tripLocationEntityIterable = datastore.prepare(tripLocationsQuery).asIterable();
 
       // delete current data relating to Trip
@@ -166,12 +166,12 @@ public class TripsServlet extends HttpServlet {
       // build TripLocation objects from request data and put them in Datastore
       JsonArray locationData = jsonObject.getAsJsonArray("locations");
       Iterator<JsonElement> locationIterator = locationData.iterator();
-      
-      while(locationIterator.hasNext()) {
-        TripLocation location = convertJsonObjectToTripLocation(locationIterator.next().getAsJsonObject(), userEmail);
-        datastore.put(txn, convertTripLocationToEntity(location, tripEntity));
+
+      while (locationIterator.hasNext()) {
+        TripLocation location = TripDataConverter.convertJsonObjectToTripLocation(locationIterator.next().getAsJsonObject(), userEmail);
+        datastore.put(txn, TripDataConverter.convertTripLocationToEntity(location, tripEntity));
       }
-    
+
       txn.commit();
     } finally {
       if (txn.isActive()) {
@@ -193,13 +193,15 @@ public class TripsServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Query tripQuery = new Query("trip")
-                        .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail))
-                        .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_TIMESTAMP, FilterOperator.EQUAL, timestamp));
-    Iterable<Entity> tripEntityIterable =  datastore.prepare(tripQuery).asIterable();
+        .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_OWNER, FilterOperator.EQUAL, userEmail))
+        .setFilter(new FilterPredicate(Trip.ENTITY_PROPERTY_TIMESTAMP, FilterOperator.EQUAL, timestamp));
+    Iterable<Entity> tripEntityIterable = datastore.prepare(tripQuery).asIterable();
 
     if (Iterables.size(tripEntityIterable) == 0) {
-      /* If we reach this breakpoint, that means no Trip matches the timestamp 
-         to be deleted. Send back an error code 404. */
+      /*
+       * If we reach this breakpoint, that means no Trip matches the timestamp to be
+       * deleted. Send back an error code 404.
+       */
       response.setStatus(HttpServletResponse.SC_NOT_FOUND);
       return;
     }
@@ -216,121 +218,5 @@ public class TripsServlet extends HttpServlet {
       datastore.delete(tripLocationEntity.getKey());
     }
     response.setStatus(HttpServletResponse.SC_OK);
-  }
-
-  /**
-   * Converts a JsonObject with certain fields to its corresponding Trip value class.
-   * @param jsonObject Object with fields for title, hotel ID, hotel name, hotel
-   *                   photo ref, and rating.
-   * @param userEmail
-   * @param timestamp
-   * @return Trip with corresponding fields to the JsonObject and params
-   */
-  private static Trip convertJsonObjectToTrip(JsonObject jsonObject, String userEmail, long timestamp) {
-    return Trip.builder()
-            .setTitle(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_TITLE).getAsString())
-            .setHotelID(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL_ID).getAsString())
-            .setHotelName(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL_NAME).getAsString())
-            .setHotelImage(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL_IMAGE).getAsString())
-            .setRating(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_RATING).getAsDouble())
-            .setOwner(userEmail)
-            .setTimestamp(timestamp)
-            .build();
-  }
-
-  /**
-   * Converts a JsonObject with certain fields to its corresponding TripLocation value class.
-   * @param jsonObject Object with fields for id, name, and weight
-   * @param userEmail
-   * @return TripLocation with corresponding fields to the JsonObject and param
-   */
-  private static TripLocation convertJsonObjectToTripLocation(JsonObject jsonObject, String userEmail) {
-    String placeID = jsonObject.getAsJsonPrimitive("id").getAsString();
-    String placeName = jsonObject.getAsJsonPrimitive("name").getAsString();
-    int weight = jsonObject.getAsJsonPrimitive("weight").getAsInt();
-    return TripLocation.create(placeID, placeName, weight, userEmail);
-  }
-
-  /**
-   * Converts an Entity of kind "trip" to the value class type.
-   * 
-   * @param entity the entity from the Datastore containing the trip data
-   * @return Trip object with corresponding fields to the entity properties
-   */
-  public static Trip convertEntityToTrip(Entity entity) {
-    String title = (String) entity.getProperty(Trip.ENTITY_PROPERTY_TITLE);
-    String hotelID = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL_ID);
-    String hotelName = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL_NAME);
-    String hotelImage = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL_IMAGE);
-    double rating = (double) entity.getProperty(Trip.ENTITY_PROPERTY_RATING);
-    String description = (String) entity.getProperty(Trip.ENTITY_PROPERTY_DESCRIPTION);
-    String owner = (String) entity.getProperty(Trip.ENTITY_PROPERTY_OWNER);
-    boolean isPastTrip = (boolean) entity.getProperty(Trip.ENTITY_PROPERTY_PAST_TRIP);
-    boolean isPublic = (boolean) entity.getProperty(Trip.ENTITY_PROPERTY_PUBLIC);
-    long timestamp = (long) entity.getProperty(Trip.ENTITY_PROPERTY_TIMESTAMP);
-
-    return Trip.builder()
-            .setTitle(title)
-            .setHotelID(hotelID)
-            .setHotelName(hotelName)
-            .setHotelImage(hotelImage)
-            .setRating(rating)
-            .setDescription(description)
-            .setOwner(owner)
-            .setIsPastTrip(isPastTrip)
-            .setIsPublic(isPublic)
-            .setTimestamp(timestamp)
-            .build();
-  }
-
-   /**
-   * Converts a certain Trip object to a corresponding Entity object.
-   * 
-   * @param trip the Trip object to be converted
-   * @return Entity object with matching property values
-   */
-  public static Entity convertTripToEntity(Trip trip) {
-    Entity tripEntity = new Entity("trip");
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_TITLE, trip.title());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_ID, trip.hotelID());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_NAME, trip.hotelName());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_IMAGE, trip.hotelImage());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_RATING, trip.rating());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_DESCRIPTION, trip.description());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_OWNER, trip.owner());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_PAST_TRIP, trip.isPastTrip());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_PUBLIC, trip.isPublic());
-    tripEntity.setProperty(Trip.ENTITY_PROPERTY_TIMESTAMP, trip.timestamp());
-    return tripEntity;
-  }
-
-  /**
-   * Converts an Entity of kind "trip-location" to the value class type.
-   * 
-   * @param entity the entity from Datastore containing TripLocation data
-   * @return TripLocation object with corresponding fields to the entity
-   */
-  public static TripLocation convertEntityToTripLocation(Entity entity) {
-    String placeID = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_PLACE_ID);
-    String placeName = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_PLACE_NAME);
-    int weight = Math.toIntExact((long) entity.getProperty(TripLocation.ENTITY_PROPERTY_WEIGHT));
-    String owner = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_OWNER);
-    return TripLocation.create(placeID, placeName, weight, owner);
-  }
-
-  /**
-   * Converts a certain TripLocation object to a corresponding Entity object.
-   * 
-   * @param location the TripLocation object to be converted
-   * @param parent   the parent Trip holding these locations
-   * @return Entity object with matching property values
-   */
-  public static Entity convertTripLocationToEntity(TripLocation location, Entity parent) {
-    Entity tripLocationEntity = new Entity("trip-location", parent.getKey());
-    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_PLACE_ID, location.placeID());
-    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_PLACE_NAME, location.placeName());
-    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_WEIGHT, location.weight());
-    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_OWNER, location.owner());
-    return tripLocationEntity;
   }
 }

--- a/src/main/java/com/google/sps/util/TripDataConverter.java
+++ b/src/main/java/com/google/sps/util/TripDataConverter.java
@@ -1,0 +1,126 @@
+package com.google.sps.util;
+
+import com.google.appengine.api.datastore.Entity;
+import com.google.gson.JsonObject;
+import com.google.sps.data.Trip;
+import com.google.sps.data.TripLocation;
+
+public class TripDataConverter {
+  /**
+   * Converts a JsonObject with certain fields to its corresponding Trip value
+   * class.
+   * 
+   * @param jsonObject Object with fields for title, hotel ID, hotel name, hotel
+   *                   photo ref, and rating.
+   * @param userEmail
+   * @param timestamp
+   * @return Trip with corresponding fields to the JsonObject and params
+   */
+  public static Trip convertJsonObjectToTrip(JsonObject jsonObject, String userEmail, long timestamp) {
+    return Trip.builder()
+            .setTitle(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_TITLE).getAsString())
+            .setHotelID(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL_ID).getAsString())
+            .setHotelName(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL_NAME).getAsString())
+            .setHotelImage(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_HOTEL_IMAGE).getAsString())
+            .setRating(jsonObject.getAsJsonPrimitive(Trip.ENTITY_PROPERTY_RATING).getAsDouble()).setOwner(userEmail)
+            .setTimestamp(timestamp).build();
+  }
+
+  /**
+   * Converts a JsonObject with certain fields to its corresponding TripLocation
+   * value class.
+   * 
+   * @param jsonObject Object with fields for id, name, and weight
+   * @param userEmail
+   * @return TripLocation with corresponding fields to the JsonObject and param
+   */
+  public static TripLocation convertJsonObjectToTripLocation(JsonObject jsonObject, String userEmail) {
+    String placeID = jsonObject.getAsJsonPrimitive("id").getAsString();
+    String placeName = jsonObject.getAsJsonPrimitive("name").getAsString();
+    int weight = jsonObject.getAsJsonPrimitive("weight").getAsInt();
+    return TripLocation.create(placeID, placeName, weight, userEmail);
+  }
+
+  /**
+   * Converts an Entity of kind "trip" to the value class type.
+   * 
+   * @param entity the entity from the Datastore containing the trip data
+   * @return Trip object with corresponding fields to the entity properties
+   */
+  public static Trip convertEntityToTrip(Entity entity) {
+    String title = (String) entity.getProperty(Trip.ENTITY_PROPERTY_TITLE);
+    String hotelID = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL_ID);
+    String hotelName = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL_NAME);
+    String hotelImage = (String) entity.getProperty(Trip.ENTITY_PROPERTY_HOTEL_IMAGE);
+    double rating = (double) entity.getProperty(Trip.ENTITY_PROPERTY_RATING);
+    String description = (String) entity.getProperty(Trip.ENTITY_PROPERTY_DESCRIPTION);
+    String owner = (String) entity.getProperty(Trip.ENTITY_PROPERTY_OWNER);
+    boolean isPastTrip = (boolean) entity.getProperty(Trip.ENTITY_PROPERTY_PAST_TRIP);
+    boolean isPublic = (boolean) entity.getProperty(Trip.ENTITY_PROPERTY_PUBLIC);
+    long timestamp = (long) entity.getProperty(Trip.ENTITY_PROPERTY_TIMESTAMP);
+
+    return Trip.builder()
+          .setTitle(title)
+          .setHotelID(hotelID)
+          .setHotelName(hotelName)
+          .setHotelImage(hotelImage)
+          .setRating(rating)
+          .setDescription(description)
+          .setOwner(owner)
+          .setIsPastTrip(isPastTrip)
+          .setIsPublic(isPublic)
+          .setTimestamp(timestamp)
+          .build();
+  }
+
+  /**
+   * Converts a certain Trip object to a corresponding Entity object.
+   * 
+   * @param trip the Trip object to be converted
+   * @return Entity object with matching property values
+   */
+  public static Entity convertTripToEntity(Trip trip) {
+    Entity tripEntity = new Entity("trip");
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_TITLE, trip.title());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_ID, trip.hotelID());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_NAME, trip.hotelName());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_HOTEL_IMAGE, trip.hotelImage());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_RATING, trip.rating());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_DESCRIPTION, trip.description());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_OWNER, trip.owner());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_PAST_TRIP, trip.isPastTrip());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_PUBLIC, trip.isPublic());
+    tripEntity.setProperty(Trip.ENTITY_PROPERTY_TIMESTAMP, trip.timestamp());
+    return tripEntity;
+  }
+
+  /**
+   * Converts an Entity of kind "trip-location" to the value class type.
+   * 
+   * @param entity the entity from Datastore containing TripLocation data
+   * @return TripLocation object with corresponding fields to the entity
+   */
+  public static TripLocation convertEntityToTripLocation(Entity entity) {
+    String placeID = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_PLACE_ID);
+    String placeName = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_PLACE_NAME);
+    int weight = Math.toIntExact((long) entity.getProperty(TripLocation.ENTITY_PROPERTY_WEIGHT));
+    String owner = (String) entity.getProperty(TripLocation.ENTITY_PROPERTY_OWNER);
+    return TripLocation.create(placeID, placeName, weight, owner);
+  }
+
+  /**
+   * Converts a certain TripLocation object to a corresponding Entity object.
+   * 
+   * @param location the TripLocation object to be converted
+   * @param parent   the parent Trip holding these locations
+   * @return Entity object with matching property values
+   */
+  public static Entity convertTripLocationToEntity(TripLocation location, Entity parent) {
+    Entity tripLocationEntity = new Entity("trip-location", parent.getKey());
+    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_PLACE_ID, location.placeID());
+    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_PLACE_NAME, location.placeName());
+    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_WEIGHT, location.weight());
+    tripLocationEntity.setProperty(TripLocation.ENTITY_PROPERTY_OWNER, location.owner());
+    return tripLocationEntity;
+  }
+}

--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -77,6 +77,33 @@
           >
         </div>
       </div>
+      <div id="trips-network-modal" class="modal">
+        <div class="modal-content">
+          <h4>Post Trip to Trips Network</h4>
+           <div class="row">
+              <form class="col s12" id="trips-network-form">
+                <div class="row">
+                  <div class="input-field col s12">
+                    <textarea id="trip-description" class="materialize-textarea"></textarea>
+                    <label for="trip-description">Describe the trip</label>
+                  </div>
+                </div>
+                <div class="row">
+                  <p class="range-field">
+                    <input type="range" id="trip-rating" min="1" max="5" step="0.5" />
+                    <label for="trip-rating">Rating (1-5)</label>
+                  </p>
+                </div>
+                <div class="row">
+                  <button id="post-trip-button" class="btn-large indigo waves-effect waves-light"><i class="material-icons left">post_add</i>Post Trip</button>
+                </div>
+              </form>
+            </div>
+        </div>
+        <div class="modal-footer">
+          <a href="#!" class="modal-close waves-effect btn-flat">Cancel</a>
+        </div>
+      </div>
       <div class="row">
         <div class="col m10">
           <h3>My Trips</h3>

--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -89,13 +89,18 @@
                   </div>
                 </div>
                 <div class="row">
-                  <p class="range-field">
-                    <input type="range" id="trip-rating" min="1" max="5" step="0.5" />
-                    <label for="trip-rating">Rating (1-5)</label>
-                  </p>
-                </div>
-                <div class="row">
-                  <button id="post-trip-button" class="btn-large indigo waves-effect waves-light"><i class="material-icons left">post_add</i>Post Trip</button>
+                  <div class="col s12 m6">
+                    <p class="range-field">
+                      <input type="range" id="trip-rating" min="1" max="5" step="0.5" />
+                      <label for="trip-rating">Rating (1-5)</label>
+                    </p>
+                  </div>
+                  <div class="col s12 m6">
+                    <button id="post-trip-button" class="btn-large indigo waves-effect waves-light right">
+                      <i class="material-icons left">post_add</i>
+                      Post Trip
+                    </button>
+                  </div>
                 </div>
               </form>
             </div>

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -754,7 +754,12 @@ async function fetchAndRenderTripsFromDB() {
               </div>
               <div id="trip-${timestamp}-locations"></div>
               <div id="trip-${timestamp}-map" class="trip-map"></div>
-            </div>
+            </div>` + 
+          isPastTrip === 'false'
+          ? `<div class="card-action">
+              <a class="btn-large indigo waves-effect" onclick="setTripToPastOrPlanned('${timestamp}', '${isPastTrip}')">This is a link</a>
+             </div>` : '' +
+          `
           </div>
         </div>
         <div class="col s12 m4" id="trip-${timestamp}-hotel-card">
@@ -996,4 +1001,31 @@ function getNumPlaceObjectsInArray(arr) {
     (acc, curr) => acc + (curr.place_id == undefined ? 0 : 1),
     0
   );
+}
+
+/**
+ * Sets a trip, identified by its timestamp, to a past trip.
+ * @param {string} timestamp 
+ * @param {string} isPastTrip - 'true' if setting trip to past trip, 'false' otherwise
+ */
+async function setTripToPastOrPlanned(timestamp, isPastTrip) {
+  const response = await fetch(`/trips-network?timestamp=${timestamp}&is_past_trip=${isPastTrip}`, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'application/json',
+    },
+  });
+  
+  if (response.ok) {
+    M.toast({
+      html:
+        "Sucessfully marked trip as completed.",
+    });
+    fetchAndRenderTripsFromDB();
+  } else {
+    M.toast({
+      html:
+        "There was an error while setting your trip to a past trip. Please try again.",
+    });
+  }
 }

--- a/src/main/webapp/styles/constant-style.css
+++ b/src/main/webapp/styles/constant-style.css
@@ -20,3 +20,8 @@
   min-height: 100vh;
   padding-bottom: 1.5em;
 }
+
+.placeholder-text {
+  color: grey;
+  font-size: 18px;
+}

--- a/src/main/webapp/styles/my-trips.css
+++ b/src/main/webapp/styles/my-trips.css
@@ -6,11 +6,6 @@
   min-height: 400px;
 }
 
-.placeholder-text {
-  color: grey;
-  font-size: 18px;
-}
-
 .trip-title-section {
   margin-left: 0 !important;
 }

--- a/src/test/java/com/google/sps/TripsServletTest.java
+++ b/src/test/java/com/google/sps/TripsServletTest.java
@@ -5,6 +5,7 @@ import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestC
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.sps.data.Trip;
 import com.google.sps.servlets.TripsServlet;
+import com.google.sps.util.TripDataConverter;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -40,7 +41,7 @@ public class TripsServletTest {
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_PAST_TRIP, false);
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_PUBLIC, true);
     tripEntity.setProperty(Trip.ENTITY_PROPERTY_TIMESTAMP, 3942943923949L);
-    Trip trip = TripsServlet.convertEntityToTrip(tripEntity);
+    Trip trip = TripDataConverter.convertEntityToTrip(tripEntity);
 
     Assert.assertEquals("foo trip", trip.title());
     Assert.assertEquals("24234235", trip.hotelID());


### PR DESCRIPTION
### Summary
This PR implements the alpha version of the Trips Network, in which users can now mark a trip as completed (aka a past trip), and then post their experience on the Trips Network. 

This PR introduces the `/trips-network` endpoint, which has `PUT`, `GET`, and `POST` requests. The `PUT` request allows a user to change a trip to a past trip, or vice-versa. While the `PATCH` verb would make more sense here, the Java Servlet framework does not support it, so I opted for `PUT` as it is also idempotent. The frontend calls these endpoints to push changes and get posts for the Trips Network, and the UI has been updated accordingly.

The `GET` request displays all trips marked as "public", which is to mean they're posted. It does this in a similar response object as the `GET` request in the TripServlet (`/trip-data`)

The `POST` request allows for a user to post their trip on the network using a certain request body.

This PR also refactors some trip entity <-> value class methods in TripsServlet to be shared in a single util class. This is one of the major contributors to the line diffs in this PR, sorry about that. 

### Screenshot
![Overnightly _ My Trips (13)](https://user-images.githubusercontent.com/7517829/88843523-437d7980-d1af-11ea-8d9f-3997896c7f36.gif)

### Test Plan
Run `mvn package appengine:run`. Add a trip or two and add them to the trips network. You can try logging in as a different email on the dev server and see that multiple accounts' posts are all shown.

### Known bug
We can't use commas in the trip description as the JSON parser in `common.js` relies on these to delimit fields. I'll fix this with TDD soon.