### PR TITLE
hotfix: Fix JSON parser to accommodate commas in values with tests

### DIFF
--- a/src/main/webapp/scripts/common.js
+++ b/src/main/webapp/scripts/common.js
@@ -155,6 +155,16 @@ function parseSerializedJson(json) {
       if (currChar !== ',' && currChar !== '}') {
         currValue += currChar;
       } else {
+        if (currChar === ',') {
+          const restOfJson = json.substring(i + 1, json.length);
+          const indexOfComma = restOfJson.indexOf(',');
+          const indexOfEquals = restOfJson.indexOf('=');
+          
+          if (indexOfComma < indexOfEquals && indexOfComma !== -1) {
+            currValue += currChar;
+            continue;
+          }
+        }
         isField = true;
         // add field to obj and reset field and value strings
         obj[currField] = currValue;

--- a/src/main/webapp/scripts/trips-network.js
+++ b/src/main/webapp/scripts/trips-network.js
@@ -37,7 +37,6 @@ async function loadSharedTripsData() {
   );
 
   const posts = [];
-  console.log(tripsData);
   for (key of keys) {
     const {
       title,

--- a/src/main/webapp/tests/common.test.js
+++ b/src/main/webapp/tests/common.test.js
@@ -34,4 +34,19 @@ describe('Test the serialized by Gson JSON parser', () => {
       title: 'test',
     });
   });
+
+  it('parses a Trip serialized JSON with commas in values correctly', () => {
+    expect(parseSerializedJson('Trip{title=broken, hotelID=aBc234, hotelName=The Hotel, hotelImage=aBcXP, rating=3.5, description=commas, but, not, broken., owner=peter@google.com, isPastTrip=true, isPublic=true, timestamp=1596136046764}')).toEqual({
+      title: 'broken',
+      hotelID: 'aBc234',
+      hotelName: 'The Hotel',
+      hotelImage: 'aBcXP',
+      rating: '3.5',
+      description: 'commas, but, not, broken.',
+      owner: 'peter@google.com',
+      isPastTrip: 'true',
+      isPublic: 'true',
+      timestamp: '1596136046764',
+    });
+  });
 });


### PR DESCRIPTION
### Motivation
In #32, the alpha version of the Trips Network was introduced. In this PR, there was a known bug with comma values corrupting the rendered cards, making them display `undefined` for some properties. This was a result of the `parseSerializedJson()` function in `common.js`, which uses commas to delimit properties and their corresponding values from one another. 

Based on this known vulnerability, I followed test-driven development and first wrote a failing test with expected behavior. My implementation strategy was to compare the relative indices of the next comma and next equals sign following the current character being parsed in the JSON string. If the comma comes first, we know that we're not done with the value yet. Otherwise, this comma is likely the delimiter.

### Screenshot
![Screenshot 2020-07-30 at 7 14 36 PM](https://user-images.githubusercontent.com/7517829/88984277-2faf4180-d29b-11ea-973f-b64f2a0fc9fe.png)

### Test Plan
Run `mvn package appengine:run`. Create a trip in My Trips and post it to the Trips Network by making it a past trip and then posting it with a description filled with copious commas. See that the JSON is still parsed correctly.

The code is also unit tested in `common.test.js` with a typical use case.
