### PR TITLE
Generalize hotel and save trip functionality

### DIFF
--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -52,7 +52,7 @@
       <div id="hotel-modal" class="modal">
         <div class="modal-content">
           <h4>Hotel Results</h4>
-          <div id="hotels-map"></div>
+          <div id="hotel-map"></div>
           <div id="hotel-results"></div>
         </div>
         <div class="modal-footer">

--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -150,7 +150,6 @@
     <script src="scripts/common-dom.js"></script>
     <script src="scripts/common-util.js"></script>
     <script src="scripts/my-trips.js"></script>
-    <script src="scripts/hotel-selection.js"></script>
     <script src="scripts/service-account.js"></script>
   </body>
 </html>

--- a/src/main/webapp/my-trips.html
+++ b/src/main/webapp/my-trips.html
@@ -150,6 +150,7 @@
     <script src="scripts/common-dom.js"></script>
     <script src="scripts/common-util.js"></script>
     <script src="scripts/my-trips.js"></script>
+    <script src="scripts/hotel-selection.js"></script>
     <script src="scripts/service-account.js"></script>
   </body>
 </html>

--- a/src/main/webapp/place-suggestions.html
+++ b/src/main/webapp/place-suggestions.html
@@ -65,11 +65,11 @@
       <div id="current-trip-modal" class="modal bottom-sheet">
         <div id="current-trip-content" class="modal-content">
           <h4>Current Trip</h4>
-          <div id='current-trip-updates'></div>
+          <div id='current-trip-status'></div>
           <ul id="current-trip-places" class="collection"></ul>
         </div>
         <div class="modal-footer">
-          <a class="modal-close waves-effect btn-flat" onclick="findHotel();">Find Hotel</a>
+          <a class="modal-close waves-effect btn-flat" onclick="findHotel(null);">Find Hotel</a>
         </div>
       </div>
 
@@ -135,6 +135,7 @@
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDlLtx69Y4-65_dCK67ZX3lzKTYpyc5CWI&libraries=places"></script>
     <script src="scripts/common-dom.js"></script>
     <script src="scripts/common-util.js"></script>
+    <script src="scripts/hotel-selection.js"></script>
     <script src="scripts/place-suggestions.js"></script>
     <script src="scripts/service-account.js"></script>
   </body>

--- a/src/main/webapp/place-suggestions.html
+++ b/src/main/webapp/place-suggestions.html
@@ -54,7 +54,7 @@
       <div id="hotel-modal" class="modal">
         <div class="modal-content">
           <h4>Hotel Results</h4>
-          <div id="hotels-map"></div>
+          <div id="hotel-map"></div>
           <div id="hotel-results"></div>
         </div>
         <div class="modal-footer">

--- a/src/main/webapp/place-suggestions.html
+++ b/src/main/webapp/place-suggestions.html
@@ -69,7 +69,7 @@
           <ul id="current-trip-places" class="collection"></ul>
         </div>
         <div class="modal-footer">
-          <a class="modal-close waves-effect btn-flat" onclick="findHotel(null);">Find Hotel</a>
+          <a class="modal-close waves-effect btn-flat" onclick="findHotel();">Find Hotel</a>
         </div>
       </div>
 

--- a/src/main/webapp/scripts/common-util.js
+++ b/src/main/webapp/scripts/common-util.js
@@ -2,7 +2,7 @@
  * Fetches image and gets temp URL of image from Google Place Photos
  * @param {string} photoRef a Place Photos photo_reference
  * @returns {string} String containing object url of the resulting image
- */
+
 async function imageURLFromPhotoRef(photoRef) {
   const photoResponse = await fetch(
     `https://cors-anywhere.herokuapp.com/https://maps.googleapis.com/maps/api/place/photo?maxwidth=500&photoreference=${photoRef}&key=${GOOGLE_API_KEY}`
@@ -10,6 +10,38 @@ async function imageURLFromPhotoRef(photoRef) {
   const blob = await photoResponse.blob();
   const photoUrl = await URL.createObjectURL(blob);
   return photoUrl;
+}
+*/
+
+/**
+ * Gets URL for photo of place or assigns it a default one if there are no photos available
+ * @param {Array} photos array of photos from PlaceResult object
+*/
+async function imageInfoFromPhotosArray(photos) {
+  const photoRef = 
+    photos && Array.isArray(photos)
+      ? photos[0].photo_reference
+      : undefined;
+
+  let photoInfo;
+  if(photoRef) {
+    const photoResponse = await fetch(
+      `https://cors-anywhere.herokuapp.com/https://maps.googleapis.com/maps/api/place/photo?maxwidth=500&photoreference=${photoRef}&key=${GOOGLE_API_KEY}`
+    );
+    const blob = await photoResponse.blob();
+    const photoUrl = await URL.createObjectURL(blob);
+    photoInfo = {
+      photoRef: photoRef,
+      photoUrl: photoUrl,
+    }
+    return photoInfo;
+  } else {
+    photoInfo = {
+      photoRef: '',
+      photoUrl: DEFAULT_PLACE_IMAGE,
+    }
+    return photoInfo;
+  }
 }
 
 /**
@@ -21,8 +53,8 @@ async function imageURLFromPhotoRef(photoRef) {
 function placesToCoordsWeightArray(arr) {
   // Build array containing {lat, lng, weight} objects
   return arr.map(({ geometry, weight }) => ({
-    lat: geometry.location.lat(),
-    lng: geometry.location.lng(),
+    lat: geometry.location.lat,
+    lng: geometry.location.lng,
     weight: weight,
   }));
 }

--- a/src/main/webapp/scripts/common-util.js
+++ b/src/main/webapp/scripts/common-util.js
@@ -20,10 +20,10 @@ async function imageURLFromPhotoRef(photoRef) {
  */
 function placesToCoordsWeightArray(arr) {
   // Build array containing {lat, lng, weight} objects
-  return arr.map(({ geometry, locationNum }) => ({
+  return arr.map(({ geometry, weight }) => ({
     lat: geometry.location.lat(),
     lng: geometry.location.lng(),
-    weight: document.getElementById(`location-${locationNum}-weight`).value,
+    weight: weight,
   }));
 }
 

--- a/src/main/webapp/scripts/common-util.js
+++ b/src/main/webapp/scripts/common-util.js
@@ -2,7 +2,7 @@
  * Fetches image and gets temp URL of image from Google Place Photos
  * @param {string} photoRef a Place Photos photo_reference
  * @returns {string} String containing object url of the resulting image
-
+*/
 async function imageURLFromPhotoRef(photoRef) {
   const photoResponse = await fetch(
     `https://cors-anywhere.herokuapp.com/https://maps.googleapis.com/maps/api/place/photo?maxwidth=500&photoreference=${photoRef}&key=${GOOGLE_API_KEY}`
@@ -11,7 +11,7 @@ async function imageURLFromPhotoRef(photoRef) {
   const photoUrl = await URL.createObjectURL(blob);
   return photoUrl;
 }
-*/
+
 
 /**
  * Gets URL for photo of place or assigns it a default one if there are no photos available

--- a/src/main/webapp/scripts/hotel-selection.js
+++ b/src/main/webapp/scripts/hotel-selection.js
@@ -1,24 +1,21 @@
 //const DOM elements for components of shared hotel modal
-const HOTEL_MAP = document.getElementById('hotel-map');
+const HOTEL_MAP_ELEM = document.getElementById('hotel-map');
 const HOTEL_RESULTS = document.getElementById('hotel-results');
 
+/**
+ * Opens modal with results for user to confirm and save trip.
+ * @param {string|null} timestamp timestamp string of the trip to be updated.
+ *                                Null if this is a new trip.
+ */
 async function findHotel(timestamp) {
-  if (numLocations !== getNumPlaceObjectsInArray(locationPlaceObjects)) {
-    M.Toast.dismissAll();
-    M.toast({
-      html: 'Not all of your places are selected through autocomplete.',
-    });
-    return;
-  }
-
-  document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
+  HOTEL_RESULTS.innerHTML = LOADING_ANIMATION_HTML;
+  HOTEL_MAP_ELEM.innerHTML = '';
+  HOTEL_MAP_ELEM.style.display = 'none';
   openHotelModal();
 
   // Get center point from which to start searching for hotels
   const coords = placesToCoordsWeightArray(locationPlaceObjects);
   const [lat, lng] = centerOfMass(coords);
-  document.getElementById('hotels-map').innerHTML = '';
-  document.getElementById('hotels-map').style.display = 'none';
 
   const response = await fetch(
     `https://cors-anywhere.herokuapp.com/https://maps.googleapis.com/maps/api/place/textsearch/json?type=lodging&location=${lat},${lng}&radius=10000&key=${GOOGLE_API_KEY}&output=json`
@@ -27,18 +24,24 @@ async function findHotel(timestamp) {
   parseAndRenderHotelResults(results, { lat: lat, lng: lng }, timestamp);
 }
 
+/**
+ * Parses response from Places API lodging query to render list of
+ * cards to the hotel results modal.
+ * @param {Object} json the resulting JS object from calling the
+ *                      Places API for the centerpoint.
+ * @param {string|null} timestamp timestamp string of the trip to be updated.
+ *                                Null if this is a new trip.
+ */
 async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
-  const modalContent = document.getElementById('hotel-results');
-  const hotelsMapElem = document.getElementById('hotels-map');
-  hotelsMapElem.style.height = '';
+  HOTEL_MAP_ELEM.style.height = '';
 
   if (!json || json.length === 0) {
-    modalContent.innerText =
+    HOTEL_RESULTS.innerText =
       "We couldn't find any hotels nearby. Sorry about that.";
   } else {
     json = json.slice(0, 10);
     const hotelMap = new google.maps.Map(
-      document.getElementById('hotels-map'),
+      HOTEL_MAP_ELEM,
       {
         center: centerPoint,
         zoom: 12,
@@ -49,7 +52,7 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
       const { position } = obj;
       const { lat, lng } = position;
       const marker = new google.maps.Marker({
-        position: { lat: lat(), lng: lng() },
+        position: { lat: lat, lng: lng },
         map: hotelMap,
         title: obj.title,
       });
@@ -68,33 +71,29 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
           text: 'hotel',
         },
       });
+
       const infoWindow = new google.maps.InfoWindow({
         content: `<h5 class="infowindow-text">${obj.name}</h5>`,
       });
       marker.addListener('click', () => infoWindow.open(hotelMap, marker));
+
       obj.distance_center = distanceBetween(location, centerPoint);
-      const photoRef =
-        obj.photos && Array.isArray(obj.photos)
-          ? obj.photos[0].photo_reference
-          : undefined;
-      if (photoRef) {
-        const photoUrl = await imageURLFromPhotoRef(photoRef);
-        obj.photo_url = photoUrl;
-        obj.photo_ref = photoRef;
-      } else {
-        obj.photo_url = undefined;
-        obj.photo_ref = '';
-      }
+      
+      const photoInfo = await imageInfoFromPhotosArray(obj.photos);
+      const { photoRef, photoUrl } = photoInfo;
+      obj.photo_url = photoUrl;
+      obj.photo_ref = photoRef;
+
       return await obj;
     });
     json = await Promise.all(json);
     json.sort((a, b) => a.distance_center - b.distance_center);
 
-    hotelsMapElem.style.display = 'block';
-    hotelsMapElem.style.width = '100%';
-    hotelsMapElem.style.height = '400px';
-    hotelsMapElem.style.marginBottom = '2em';
-    modalContent.innerHTML = json
+    HOTEL_MAP_ELEM.style.display = 'block';
+    HOTEL_MAP_ELEM.style.width = '100%';
+    HOTEL_MAP_ELEM.style.height = '400px';
+    HOTEL_MAP_ELEM.style.marginBottom = '2em';
+    HOTEL_RESULTS.innerHTML = json
       .map(
         ({ name, formatted_address, rating, place_id, photo_url, photo_ref }) =>
           `
@@ -139,6 +138,54 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
       )
       .join('');
   }
+}
+
+/**
+ * Saves the current trip the user is editing to My Trips, through a POST request
+ * to the backend. Then rerenders the trips based on DB data.
+ * @param {string} hotelID  the Place ID for the hotel
+ * @param {string} hotelRef the photo reference in Google Place Photos for the hotel.
+ * @param {string} hotelName the name of the hotel
+ * @param {string|null|undefined} timestamp timestamp string of the trip to be updated.
+ *                                          Null/undefined if this is a new trip.
+ */
+async function saveTrip(hotelID, hotelRef, hotelName, timestamp) {
+  closeHotelModal();
+
+  // Build location and weight arrays
+  const locationData = [];
+  for (let i = 1; i <= numLocations; i++) {
+    locationData.push({
+      id: locationPlaceObjects[i - 1].place_id,
+      name: locationPlaceObjects[i - 1].name,
+      weight: locationPlaceObjects[i - 1].weight,
+    });
+  }
+
+  const tripTitleElem = document.getElementById('trip-title');
+  const tripTitle = tripTitleElem ? tripTitleElem.value : 'Plan For Me Trip';
+  const requestBody = {
+    title: tripTitle,
+    hotel_id: hotelID,
+    hotel_img: hotelRef,
+    hotel_name: hotelName,
+    rating: -1,
+    locations: locationData,
+  };
+
+  if (timestamp) {
+    requestBody.timestamp = timestamp;
+  }
+
+  const response = await fetch('/trip-data', {
+    method: timestamp ? 'PUT' : 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  resetPage(response);
 }
 
 function openHotelModal() {

--- a/src/main/webapp/scripts/hotel-selection.js
+++ b/src/main/webapp/scripts/hotel-selection.js
@@ -7,7 +7,7 @@ const HOTEL_RESULTS = document.getElementById('hotel-results');
  * @param {string|null} timestamp timestamp string of the trip to be updated.
  *                                Null if this is a new trip.
  */
-async function findHotel(timestamp) {
+async function fetchHotelResults(timestamp) {
   HOTEL_RESULTS.innerHTML = LOADING_ANIMATION_HTML;
   HOTEL_MAP_ELEM.innerHTML = '';
   HOTEL_MAP_ELEM.style.display = 'none';
@@ -185,7 +185,7 @@ async function saveTrip(hotelID, hotelRef, hotelName, timestamp) {
     body: JSON.stringify(requestBody),
   });
 
-  resetPage(response);
+  resetPage(response, timestamp, tripTitle);
 }
 
 function openHotelModal() {

--- a/src/main/webapp/scripts/hotel-selection.js
+++ b/src/main/webapp/scripts/hotel-selection.js
@@ -1,3 +1,7 @@
+//const DOM elements for components of shared hotel modal
+const HOTEL_MAP = document.getElementById('hotel-map');
+const HOTEL_RESULTS = document.getElementById('hotel-results');
+
 async function findHotel(timestamp) {
   document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
   if (numLocations !== getNumPlaceObjectsInArray(locationPlaceObjects)) {
@@ -136,6 +140,18 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
       )
       .join('');
   }
+}
+
+function openHotelModal() {
+  const HOTEL_MODAL_ELEM = document.getElementById('hotel-modal');
+  const HOTEL_MODAL_INSTANCE = M.Modal.getInstance(HOTEL_MODAL_ELEM);
+  HOTEL_MODAL_INSTANCE.open();
+}
+
+function closeHotelModal() {
+  const HOTEL_MODAL_ELEM = document.getElementById('hotel-modal');
+  const HOTEL_MODAL_INSTANCE = M.Modal.getInstance(HOTEL_MODAL_ELEM);
+  HOTEL_MODAL_INSTANCE.close();
 }
 
 

--- a/src/main/webapp/scripts/hotel-selection.js
+++ b/src/main/webapp/scripts/hotel-selection.js
@@ -3,7 +3,6 @@ const HOTEL_MAP = document.getElementById('hotel-map');
 const HOTEL_RESULTS = document.getElementById('hotel-results');
 
 async function findHotel(timestamp) {
-  document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
   if (numLocations !== getNumPlaceObjectsInArray(locationPlaceObjects)) {
     M.Toast.dismissAll();
     M.toast({
@@ -11,9 +10,9 @@ async function findHotel(timestamp) {
     });
     return;
   }
-  const elem = document.getElementById('hotel-modal');
-  const instance = M.Modal.getInstance(elem);
-  instance.open();
+
+  document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
+  openHotelModal();
 
   // Get center point from which to start searching for hotels
   const coords = placesToCoordsWeightArray(locationPlaceObjects);

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -374,7 +374,6 @@ function cancelTripCreation() {
  *                                Null if this is a new trip.
  */
 async function findHotel(timestamp) {
-  document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
   if (numLocations !== getNumPlaceObjectsInArray(locationPlaceObjects)) {
     M.Toast.dismissAll();
     M.toast({
@@ -382,11 +381,14 @@ async function findHotel(timestamp) {
     });
     return;
   }
+
+  document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
   const elem = document.getElementById('hotel-modal');
   const instance = M.Modal.getInstance(elem);
   instance.open();
 
   // Get center point from which to start searching for hotels
+  getPlaceWeights(locationPlaceObjects);
   const coords = placesToCoordsWeightArray(locationPlaceObjects);
   const [lat, lng] = centerOfMass(coords);
   document.getElementById('hotels-map').innerHTML = '';
@@ -536,13 +538,13 @@ async function saveTrip(hotelID, hotelRef, hotelName, timestamp) {
   instance.close();
 
   // Build location and weight arrays
+  getPlaceWeights(locationPlaceObjects);
   const locationData = [];
-
   for (let i = 1; i <= numLocations; i++) {
     locationData.push({
       id: locationPlaceObjects[i - 1].place_id,
       name: locationPlaceObjects[i - 1].name,
-      weight: document.getElementById(`location-${i}-weight`).value,
+      weight: locationPlaceObjects[i - 1].weight,
     });
   }
 
@@ -1006,5 +1008,15 @@ async function postTripToTripsNetwork(timestamp) {
       html:
         'There was an error while posting your trip to the Trips Network. Please try again.',
     });
+  }
+}
+
+/**
+ * Updates weights of place objects in array
+ * @param {Array} arr an array of places
+ */
+function getPlaceWeights(arr) {
+  for(let obj of arr) {
+    obj.weight = document.getElementById(`location-${obj.locationNum}-weight`).value;
   }
 }

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -13,9 +13,6 @@ let locationPlaceObjects;
 let mapInitialized;
 let markers;
 
-const HOTEL_MAP_ELEM = document.getElementById('hotel-map');
-const HOTEL_RESULTS = document.getElementById('hotel-results');
-
 /**
  * Adds a trip editor interface to the DOM, which the user can use to add a trip.
  * @param {string|null} timestamp timestamp string of the trip to be updated.
@@ -385,187 +382,14 @@ async function findHotel(timestamp) {
     return;
   }
 
-  HOTEL_RESULTS.innerHTML = LOADING_ANIMATION_HTML;
-  HOTEL_MAP_ELEM.innerHTML = '';
-  HOTEL_MAP_ELEM.style.display = 'none';
-  openHotelModal();
+  console.log(locationPlaceObjects);
 
-  // Get center point from which to start searching for hotels
   getPlaceWeights(locationPlaceObjects);
-  const coords = placesToCoordsWeightArray(locationPlaceObjects);
-  const [lat, lng] = centerOfMass(coords);
-
-  const response = await fetch(
-    `https://cors-anywhere.herokuapp.com/https://maps.googleapis.com/maps/api/place/textsearch/json?type=lodging&location=${lat},${lng}&radius=10000&key=${GOOGLE_API_KEY}&output=json`
-  );
-  const { results } = await response.json();
-  parseAndRenderHotelResults(results, { lat: lat, lng: lng }, timestamp);
+  convertLatLngFunctionsToValues(locationPlaceObjects, markers);
+  fetchHotelResults(timestamp);
 }
 
-/**
- * Parses response from Places API lodging query to render list of
- * cards to the hotel results modal.
- * @param {Object} json the resulting JS object from calling the
- *                      Places API for the centerpoint.
- * @param {string|null} timestamp timestamp string of the trip to be updated.
- *                                Null if this is a new trip.
- */
-async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
-  HOTEL_MAP_ELEM.style.height = '';
-
-  if (!json || json.length === 0) {
-    HOTEL_RESULTS.innerText =
-      "We couldn't find any hotels nearby. Sorry about that.";
-  } else {
-    json = json.slice(0, 10);
-    const hotelMap = new google.maps.Map(
-      HOTEL_MAP_ELEM,
-      {
-        center: centerPoint,
-        zoom: 12,
-      }
-    );
-    // Add existing locations to the map
-    markers.forEach((obj) => {
-      const { position } = obj;
-      const { lat, lng } = position;
-      const marker = new google.maps.Marker({
-        position: { lat: lat(), lng: lng() },
-        map: hotelMap,
-        title: obj.title,
-      });
-    });
-    // Add distance_center and photo_url fields to each object in
-    // json.results
-    json = json.map(async (obj) => {
-      const { geometry } = obj;
-      const { location } = geometry;
-      const marker = new google.maps.Marker({
-        position: location,
-        map: hotelMap,
-        title: obj.name,
-        label: {
-          fontFamily: 'Material Icons',
-          text: 'hotel',
-        },
-      });
-      const infoWindow = new google.maps.InfoWindow({
-        content: `<h5 class="infowindow-text">${obj.name}</h5>`,
-      });
-      marker.addListener('click', () => infoWindow.open(hotelMap, marker));
-      obj.distance_center = distanceBetween(location, centerPoint);
-      const photoRef =
-        obj.photos && Array.isArray(obj.photos)
-          ? obj.photos[0].photo_reference
-          : undefined;
-      if (photoRef) {
-        const photoUrl = await imageURLFromPhotoRef(photoRef);
-        obj.photo_url = photoUrl;
-        obj.photo_ref = photoRef;
-      } else {
-        obj.photo_url = undefined;
-        obj.photo_ref = '';
-      }
-      return await obj;
-    });
-    json = await Promise.all(json);
-    json.sort((a, b) => a.distance_center - b.distance_center);
-
-    HOTEL_MAP_ELEM.style.display = 'block';
-    HOTEL_MAP_ELEM.style.width = '100%';
-    HOTEL_MAP_ELEM.style.height = '400px';
-    HOTEL_MAP_ELEM.style.marginBottom = '2em';
-    HOTEL_RESULTS.innerHTML = json
-      .map(
-        ({ name, formatted_address, rating, place_id, photo_url, photo_ref }) =>
-          `
-          <div class="row">
-            <div class="col s12 m6">
-              <div class="card large white">` +
-          (photo_url
-            ? `
-                <div class="card-image">
-                  <img src="${photo_url}" alt="photo of ${name} from Google" loading="lazy" />
-                </div> `
-            : '') +
-          `
-                <div class="card-content black-text">
-                  <span class="card-title"><strong>${name}</strong></span>
-                  <p>${formatted_address}</p>
-                </div>
-                <div class="card-action center">
-                  <button
-                    class="btn indigo" 
-                    onClick="saveTrip('${place_id}', 
-                                      '${photo_ref}', 
-                                      '${name.replace(/'/g, "\\'")}',
-                                       ${timestamp})"
-                  >
-                    CHOOSE
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div class="col s12 m6">
-              <div class="card large white">
-                <div class="card-content black-text">
-                  <span class="card-title"><i class="material-icons">info</i>Info</span>
-                  <p>Rating: ${rating}</p>
-                  <p class="placeholder-text">More coming soon!</p>
-                </div>            
-              </div>
-            </div>
-          </div>
-        `
-      )
-      .join('');
-  }
-}
-
-/**
- * Saves the current trip the user is editing to My Trips, through a POST request
- * to the backend. Then rerenders the trips based on DB data.
- * @param {string} hotelID  the Place ID for the hotel
- * @param {string} hotelRef the photo reference in Google Place Photos for the hotel.
- * @param {string} hotelName the name of the hotel
- * @param {string|null|undefined} timestamp timestamp string of the trip to be updated.
- *                                          Null/undefined if this is a new trip.
- */
-async function saveTrip(hotelID, hotelRef, hotelName, timestamp) {
-  closeHotelModal();
-
-  // Build location and weight arrays
-  getPlaceWeights(locationPlaceObjects); //in case user 
-  const locationData = [];
-  for (let i = 1; i <= numLocations; i++) {
-    locationData.push({
-      id: locationPlaceObjects[i - 1].place_id,
-      name: locationPlaceObjects[i - 1].name,
-      weight: locationPlaceObjects[i - 1].weight,
-    });
-  }
-
-  const tripTitle = document.getElementById('trip-title').value;
-  const requestBody = {
-    title: tripTitle,
-    hotel_id: hotelID,
-    hotel_img: hotelRef,
-    hotel_name: hotelName,
-    rating: -1,
-    locations: locationData,
-  };
-
-  if (timestamp) {
-    requestBody.timestamp = timestamp;
-  }
-
-  const response = await fetch('/trip-data', {
-    method: timestamp ? 'PUT' : 'POST',
-    headers: {
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify(requestBody),
-  });
+function resetPage(response, timestamp, tripTitle) {
   if (response.ok) {
     if (timestamp) {
       M.toast({
@@ -1018,14 +842,24 @@ function getPlaceWeights(arr) {
   }
 }
 
-function openHotelModal() {
-  const HOTEL_MODAL_ELEM = document.getElementById('hotel-modal');
-  const HOTEL_MODAL_INSTANCE = M.Modal.getInstance(HOTEL_MODAL_ELEM);
-  HOTEL_MODAL_INSTANCE.open();
-}
+function convertLatLngFunctionsToValues(locationPlaceObjects, markers) {
+  for(let location of locationPlaceObjects) {
+    const { lat, lng } = location.geometry.location;
+    if(typeof lat === 'function') {
+      location.geometry.location.lat= lat();
+    }
+    if(typeof lng === 'function') {
+      location.geometry.location.lng = lng();
+    }
+  }
 
-function closeHotelModal() {
-  const HOTEL_MODAL_ELEM = document.getElementById('hotel-modal');
-  const HOTEL_MODAL_INSTANCE = M.Modal.getInstance(HOTEL_MODAL_ELEM);
-  HOTEL_MODAL_INSTANCE.close();
+  for(let marker of markers) {
+    const { lat, lng } = marker.position;
+    if(typeof lat === 'function') {
+      marker.position.lat = lat();
+    }
+    if(typeof lng === 'function') {
+      marker.position.lng = lng();
+    }
+  }
 }

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -13,6 +13,9 @@ let locationPlaceObjects;
 let mapInitialized;
 let markers;
 
+const HOTEL_MAP_ELEM = document.getElementById('hotel-map');
+const HOTEL_RESULTS = document.getElementById('hotel-results');
+
 /**
  * Adds a trip editor interface to the DOM, which the user can use to add a trip.
  * @param {string|null} timestamp timestamp string of the trip to be updated.
@@ -382,9 +385,9 @@ async function findHotel(timestamp) {
     return;
   }
 
-  document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
-  document.getElementById('hotel-map').innerHTML = '';
-  document.getElementById('hotel-map').style.display = 'none';
+  HOTEL_RESULTS.innerHTML = LOADING_ANIMATION_HTML;
+  HOTEL_MAP_ELEM.innerHTML = '';
+  HOTEL_MAP_ELEM.style.display = 'none';
   openHotelModal();
 
   // Get center point from which to start searching for hotels
@@ -408,17 +411,15 @@ async function findHotel(timestamp) {
  *                                Null if this is a new trip.
  */
 async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
-  const modalContent = document.getElementById('hotel-results');
-  const hotelsMapElem = document.getElementById('hotel-map');
-  hotelsMapElem.style.height = '';
+  HOTEL_MAP_ELEM.style.height = '';
 
   if (!json || json.length === 0) {
-    modalContent.innerText =
+    HOTEL_RESULTS.innerText =
       "We couldn't find any hotels nearby. Sorry about that.";
   } else {
     json = json.slice(0, 10);
     const hotelMap = new google.maps.Map(
-      document.getElementById('hotel-map'),
+      HOTEL_MAP_ELEM,
       {
         center: centerPoint,
         zoom: 12,
@@ -470,11 +471,11 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
     json = await Promise.all(json);
     json.sort((a, b) => a.distance_center - b.distance_center);
 
-    hotelsMapElem.style.display = 'block';
-    hotelsMapElem.style.width = '100%';
-    hotelsMapElem.style.height = '400px';
-    hotelsMapElem.style.marginBottom = '2em';
-    modalContent.innerHTML = json
+    HOTEL_MAP_ELEM.style.display = 'block';
+    HOTEL_MAP_ELEM.style.width = '100%';
+    HOTEL_MAP_ELEM.style.height = '400px';
+    HOTEL_MAP_ELEM.style.marginBottom = '2em';
+    HOTEL_RESULTS.innerHTML = json
       .map(
         ({ name, formatted_address, rating, place_id, photo_url, photo_ref }) =>
           `

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -383,16 +383,14 @@ async function findHotel(timestamp) {
   }
 
   document.getElementById('hotel-results').innerHTML = LOADING_ANIMATION_HTML;
-  const elem = document.getElementById('hotel-modal');
-  const instance = M.Modal.getInstance(elem);
-  instance.open();
+  document.getElementById('hotel-map').innerHTML = '';
+  document.getElementById('hotel-map').style.display = 'none';
+  openHotelModal();
 
   // Get center point from which to start searching for hotels
   getPlaceWeights(locationPlaceObjects);
   const coords = placesToCoordsWeightArray(locationPlaceObjects);
   const [lat, lng] = centerOfMass(coords);
-  document.getElementById('hotel-map').innerHTML = '';
-  document.getElementById('hotel-map').style.display = 'none';
 
   const response = await fetch(
     `https://cors-anywhere.herokuapp.com/https://maps.googleapis.com/maps/api/place/textsearch/json?type=lodging&location=${lat},${lng}&radius=10000&key=${GOOGLE_API_KEY}&output=json`
@@ -533,12 +531,10 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
  *                                          Null/undefined if this is a new trip.
  */
 async function saveTrip(hotelID, hotelRef, hotelName, timestamp) {
-  const elem = document.getElementById('hotel-modal');
-  const instance = M.Modal.getInstance(elem);
-  instance.close();
+  closeHotelModal();
 
   // Build location and weight arrays
-  getPlaceWeights(locationPlaceObjects);
+  getPlaceWeights(locationPlaceObjects); //in case user 
   const locationData = [];
   for (let i = 1; i <= numLocations; i++) {
     locationData.push({
@@ -1019,4 +1015,16 @@ function getPlaceWeights(arr) {
   for(let obj of arr) {
     obj.weight = document.getElementById(`location-${obj.locationNum}-weight`).value;
   }
+}
+
+function openHotelModal() {
+  const HOTEL_MODAL_ELEM = document.getElementById('hotel-modal');
+  const HOTEL_MODAL_INSTANCE = M.Modal.getInstance(HOTEL_MODAL_ELEM);
+  HOTEL_MODAL_INSTANCE.open();
+}
+
+function closeHotelModal() {
+  const HOTEL_MODAL_ELEM = document.getElementById('hotel-modal');
+  const HOTEL_MODAL_INSTANCE = M.Modal.getInstance(HOTEL_MODAL_ELEM);
+  HOTEL_MODAL_INSTANCE.close();
 }

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -391,8 +391,8 @@ async function findHotel(timestamp) {
   getPlaceWeights(locationPlaceObjects);
   const coords = placesToCoordsWeightArray(locationPlaceObjects);
   const [lat, lng] = centerOfMass(coords);
-  document.getElementById('hotels-map').innerHTML = '';
-  document.getElementById('hotels-map').style.display = 'none';
+  document.getElementById('hotel-map').innerHTML = '';
+  document.getElementById('hotel-map').style.display = 'none';
 
   const response = await fetch(
     `https://cors-anywhere.herokuapp.com/https://maps.googleapis.com/maps/api/place/textsearch/json?type=lodging&location=${lat},${lng}&radius=10000&key=${GOOGLE_API_KEY}&output=json`
@@ -411,7 +411,7 @@ async function findHotel(timestamp) {
  */
 async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
   const modalContent = document.getElementById('hotel-results');
-  const hotelsMapElem = document.getElementById('hotels-map');
+  const hotelsMapElem = document.getElementById('hotel-map');
   hotelsMapElem.style.height = '';
 
   if (!json || json.length === 0) {
@@ -420,7 +420,7 @@ async function parseAndRenderHotelResults(json, centerPoint, timestamp) {
   } else {
     json = json.slice(0, 10);
     const hotelMap = new google.maps.Map(
-      document.getElementById('hotels-map'),
+      document.getElementById('hotel-map'),
       {
         center: centerPoint,
         zoom: 12,

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -382,13 +382,17 @@ async function findHotel(timestamp) {
     return;
   }
 
-  console.log(locationPlaceObjects);
-
   getPlaceWeights(locationPlaceObjects);
   convertLatLngFunctionsToValues(locationPlaceObjects, markers);
   fetchHotelResults(timestamp);
 }
 
+/**
+ * Resets page to default following saving trip
+ * @param {Object} response HTTP response after saving trip
+ * @param {string|null} timestamp timestamp string of trip to be updates. Null if new trip
+ * @param {string} tripTitle title of trip 
+ */
 function resetPage(response, timestamp, tripTitle) {
   if (response.ok) {
     if (timestamp) {
@@ -842,6 +846,12 @@ function getPlaceWeights(arr) {
   }
 }
 
+/**
+ * Converts lat and lng properties in place and marker objects from their getter functions
+ * to the values these functions return instead
+ * @param {Array} locationPlaceObjects array of place objects
+ * @param {Array} markers array of marker objects 
+ */
 function convertLatLngFunctionsToValues(locationPlaceObjects, markers) {
   for(let location of locationPlaceObjects) {
     const { lat, lng } = location.geometry.location;

--- a/src/main/webapp/scripts/place-suggestions.js
+++ b/src/main/webapp/scripts/place-suggestions.js
@@ -165,17 +165,17 @@ function openCurrentTrip() {
   const currTripModalElem = document.getElementById('current-trip-modal');
   const currTripModalInstance = M.Modal.getInstance(currTripModalElem);
 
+  currTripStatus.innerHTML = '';
+  currTripPlacesCollection.innerHTML = '';
   if(locationPlaceObjects.length <= 0 || !locationPlaceObjects) {
     currTripStatus.innerHTML = "<p>It's lonely in here, add some places!</p>";
     currTripModalInstance.open();
     return;
   }
 
-  currTripStatus.innerHTML = '';
   currTripStatus.innerHTML = LOADING_ANIMATION_HTML;
   currTripModalInstance.open();
 
-  currTripPlacesCollection.innerHTML = '';
   let currTripPlaceCards = []
   for(let location of locationPlaceObjects) {
     const { name } = location;
@@ -196,7 +196,18 @@ function openCurrentTrip() {
 }
 
 function resetPage(response) {
-
+  if (response.ok) {
+    M.toast({
+      html: 'Successfully saved trip',
+    });
+    locationPlaceObjects.length = 0;
+    openCurrentTrip();
+  } else {
+    M.toast({
+      html:
+        'There was an error while saving your trip. Please try again.',
+    });
+  }
 }
 /*
 function findHotel() {

--- a/src/main/webapp/scripts/place-suggestions.js
+++ b/src/main/webapp/scripts/place-suggestions.js
@@ -3,7 +3,6 @@ let filter;
 let placeDetailsMap = new Map();
 
 //util functions rely on these specific variable names
-//kinda crappy...too bad! 
 let locationPlaceObjects = [];
 let markers = [];
 let numLocations = 0;
@@ -12,6 +11,9 @@ const DEFAULT_WEIGHT = 3;
 const PLACE_CARDS_CONTAINER = document.getElementById('place-cards-container');
 const DEFAULT_PLACE_IMAGE = '../assets/img/jason-dent-blue.jpg'
 
+/**
+ * Runs on page load. Adds auth wall and event listeners for input forms
+ */
 function init() {
   document.getElementById('plan-for-me-link').classList.add('active');
   document.getElementById('plan-for-me-link-m').classList.add('active');
@@ -20,6 +22,10 @@ function init() {
   addFilterHandler();
 }
 
+/**
+ * Adds event listener to city input form so user can select a city from
+ * autocomplete suggestions.
+ */
 function addCityAutocomplete() {
   const cityInputField = document.getElementById('city-input')
   const options = {
@@ -34,6 +40,9 @@ function addCityAutocomplete() {
   });
 }
 
+/**
+ * adds event listener to when user selects a filter
+ */
 function addFilterHandler() {
   const filterForm = document.getElementById('filters');
   filterForm.addEventListener('change', () => {
@@ -144,10 +153,17 @@ function renderPlaceCards(placeDetailsMap) {
   PLACE_CARDS_CONTAINER.innerHTML = placeCards.join('');
 }
 
+/**
+ * Adds place to array of places for trip as well as creates marker for this trip
+ * and adds it to a markers array
+ * @param {string} placeId place ID of place they want to add to trip
+ */
 function addPlaceToTrip(placeId) {
+  //add place details to array of trip locations
   const placeDetails = placeDetailsMap.get(placeId);
   locationPlaceObjects.push(placeDetails);
 
+  //add marker for each trip location to array
   const { geometry, name } = placeDetails;
   const { location } = geometry;
   const marker = {
@@ -159,6 +175,9 @@ function addPlaceToTrip(placeId) {
   numLocations++;
 }
 
+/**
+ * Opens current trip modal that user saves locations they want to visit to
+ */
 function openCurrentTrip() {
   const currTripStatus = document.getElementById('current-trip-status');
   const currTripPlacesCollection = document.getElementById('current-trip-places');
@@ -195,7 +214,29 @@ function openCurrentTrip() {
   }
 }
 
-function resetPage(response) {
+/**
+ * Opens modal with results for user to confirm and save trip.
+ */
+function findHotel() {
+  if(locationPlaceObjects.length <= 0 || !locationPlaceObjects) {
+    M.Toast.dismissAll();
+    M.toast({
+      html: 'Select some places first!',
+    });
+    return;
+  }
+
+  //null input to account for no timestamp as this is a new trip
+  fetchHotelResults(null);
+}
+
+/**
+ * Resets page to default following saving trip
+ * @param {Object} response HTTP response after saving trip
+ * @param {string|null} timestamp timestamp string of trip to be updates. Null if new trip
+ * @param {string} tripTitle title of trip (null for Plan For Me page)
+ */
+function resetPage(response, timestamp, tripTitle) {
   if (response.ok) {
     M.toast({
       html: 'Successfully saved trip',
@@ -209,17 +250,7 @@ function resetPage(response) {
     });
   }
 }
-/*
-function findHotel() {
-  if(locationData.length <= 0 || !locationData) {
-    M.Toast.dismissAll();
-    M.toast({
-      html: 'Select some places first!',
-    });
-    return;
-  }
-}
-*/
+
 /**
  * Fetches more details about place such as phone number and website and puts it all into an object
  * @param {String} placeId place ID of place to get details about 

--- a/src/main/webapp/scripts/place-suggestions.js
+++ b/src/main/webapp/scripts/place-suggestions.js
@@ -1,6 +1,7 @@
 let city;
 let filter;
 let placesMap = new Map();
+let tripPlaceMap = new Map();
 let locationData = [];
 
 const PLACE_CARDS_CONTAINER = document.getElementById('place-cards-container');
@@ -140,23 +141,23 @@ function renderPlaceCards(placesMap) {
 
 function addPlaceToTrip(placeId) {
   const placeDetails = placesMap.get(placeId);
-  locationData.push(placeDetails);
+  tripPlaceMap.set()
 }
 
 function openCurrentTrip() {
-  const currTripUpdates = document.getElementById('current-trip-updates');
+  const currTripStatus = document.getElementById('current-trip-updates');
   const currTripPlacesCollection = document.getElementById('current-trip-places');
   const currTripModalElem = document.getElementById('current-trip-modal');
   const currTripModalInstance = M.Modal.getInstance(currTripModalElem);
 
   if(locationData.length <= 0 || !locationData) {
-    currTripUpdates.innerHTML = "<p>It's lonely in here, add some places!</p>";
+    currTripStatus.innerHTML = "<p>It's lonely in here, add some places!</p>";
     currTripModalInstance.open();
     return;
   }
 
-  currTripUpdates.innerHTML = '';
-  currTripUpdates.innerHTML = LOADING_ANIMATION_HTML;
+  currTripStatus.innerHTML = '';
+  currTripStatus.innerHTML = LOADING_ANIMATION_HTML;
   currTripModalInstance.open();
 
   currTripPlacesCollection.innerHTML = '';
@@ -174,7 +175,7 @@ function openCurrentTrip() {
         </li>
       `
     )
-    currTripUpdates.innerHTML = '';
+    currTripStatus.innerHTML = '';
     currTripPlacesCollection.innerHTML = currTripPlaceCards.join('');
   }
 }


### PR DESCRIPTION
### Summary
This pulll request extend hotel selection and save trip functionality to Plan For Me page, which involved:
- [x] Copy data structure schema for places and markers across pages by either making sure all necessary properties were fetched so they matched backend schema or creating conversion functions so generalized util functions would work across pages
- [x] Separate DOM specific functions from generalized hotel selection and save trip functions
- [x] Create const variables to hold shared DOM elements such as hotel modal components

### Test Plan
Run `mvn package appengine:run`. See that you can select a hotel and save a trip from Plan For Me page and that all original functionality in My Trips page is maintained

### Notes
This improves code modularity, though refactoring to use similar API calls would remove the need for any conversion functions. 