### PR TITLE
hotfix: My Trips edit with new weights bug in prod + show when trip posted in UI

### DIFF
--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -392,7 +392,7 @@ async function findHotel(timestamp) {
  * Resets page to default following saving trip
  * @param {Object} response HTTP response after saving trip
  * @param {string|null} timestamp timestamp string of trip to be updates. Null if new trip
- * @param {string} tripTitle title of trip 
+ * @param {string} tripTitle title of trip
  */
 function resetPage(response, timestamp, tripTitle) {
   if (response.ok) {
@@ -539,17 +539,18 @@ async function fetchAndRenderTripsFromDB() {
               </div>
               <div id="trip-${timestamp}-locations"></div>
               <div id="trip-${timestamp}-map" class="trip-map"></div>
-            </div>` +
-      (isPastTrip === 'false'
-        ? `<div class="card-action center">
-                <a class="btn indigo waves-effect" onclick="setTripToPastOrPlanned('${timestamp}', 'true')">Mark Trip Completed</a>
-              </div>`
-        : `<div class="card-action center">
-                <a class="btn indigo waves-effect" onclick="setTripToPastOrPlanned('${timestamp}', 'false')">Mark Trip Planned</a>
-                <a class="btn indigo waves-effect" onclick="openTripsNetworkModal('${timestamp}')">Post on Trips Network</a>
-              </div>`) +
-      `
+            </div>
+          <div class="card-action center">` +
+            (isPastTrip === 'false'
+              ? `<a class="btn indigo waves-effect action-btn" onclick="setTripToPastOrPlanned('${timestamp}', 'true')">Mark Trip Completed</a>`
+              : `<a class="btn indigo waves-effect action-btn" onclick="setTripToPastOrPlanned('${timestamp}', 'false')">Mark Trip Planned</a>`
+              + (isPublic === 'true'
+                    ? `<a class="btn indigo disabled action-btn" onclick="openTripsNetworkModal('${timestamp}')">Trip Posted</a>`
+                    : `<a class="btn indigo waves-effect action-btn" onclick="openTripsNetworkModal('${timestamp}')">Post on Trips Network</a>`
+                )
+            ) + `   
           </div>
+        </div>
         </div>
         <div class="col s12 m4" id="trip-${timestamp}-hotel-card">
           <div class="card large">
@@ -842,8 +843,10 @@ async function postTripToTripsNetwork(timestamp) {
  * @param {Array} arr an array of places
  */
 function getPlaceWeights(arr) {
-  for(let obj of arr) {
-    obj.weight = document.getElementById(`location-${obj.locationNum}-weight`).value;
+  for (let obj of arr) {
+    obj.weight = document.getElementById(
+      `location-${obj.locationNum}-weight`
+    ).value;
   }
 }
 
@@ -851,25 +854,25 @@ function getPlaceWeights(arr) {
  * Converts lat and lng properties in place and marker objects from their getter functions
  * to the values these functions return instead
  * @param {Array} locationPlaceObjects array of place objects
- * @param {Array} markers array of marker objects 
+ * @param {Array} markers array of marker objects
  */
 function convertLatLngFunctionsToValues(locationPlaceObjects, markers) {
-  for(let location of locationPlaceObjects) {
+  for (let location of locationPlaceObjects) {
     const { lat, lng } = location.geometry.location;
-    if(typeof lat === 'function') {
-      location.geometry.location.lat= lat();
+    if (typeof lat === 'function') {
+      location.geometry.location.lat = lat();
     }
-    if(typeof lng === 'function') {
+    if (typeof lng === 'function') {
       location.geometry.location.lng = lng();
     }
   }
 
-  for(let marker of markers) {
+  for (let marker of markers) {
     const { lat, lng } = marker.position;
-    if(typeof lat === 'function') {
+    if (typeof lat === 'function') {
       marker.position.lat = lat();
     }
-    if(typeof lng === 'function') {
+    if (typeof lng === 'function') {
       marker.position.lng = lng();
     }
   }

--- a/src/main/webapp/scripts/my-trips.js
+++ b/src/main/webapp/scripts/my-trips.js
@@ -333,6 +333,7 @@ function deleteLocation(locationNum) {
     locationContainer.id = `${locationShift}-container`;
     locationLabel.id = `${locationShift}-label`;
     location.id = `${locationShift}`;
+    weight.id = `${locationShift}-weight`;
 
     weightLabel.id = `${locationShift}-weight-label`;
     weight.id = `${locationShift}-weight`;

--- a/src/main/webapp/styles/my-trips.css
+++ b/src/main/webapp/styles/my-trips.css
@@ -6,6 +6,10 @@
   min-height: 400px;
 }
 
+.action-btn {
+  margin: 0 0.5em 0 0.5em;
+}
+
 .trip-title-section {
   margin-left: 0 !important;
 }


### PR DESCRIPTION
### Summary
This PR fixes an embarassing bug in production: the weight element in the DOM has an ID that doesn't get updated when locations are deleted. Since the new `getPlaceWeights` helper is dependent on `location-n-weight` to be the ID of each weight, this resulted in a bug in a specific situation described in the Test Plan.

Also, this PR adds a small UI/UX improvement to show the user that a trip is posted.

### Screenshots
![ijAzoFw](https://user-images.githubusercontent.com/7517829/89591620-a78be780-d818-11ea-9564-fbf966382bec.gif)

### Test Plan
Run `mvn package appengine:run`. Add some locations (at least three) and delete one in the middle. Then add another location and change its weight and try to go to the next stage. See that it works.
